### PR TITLE
Fix week detection in document parsers

### DIFF
--- a/backend/parsers/parser_docx.py
+++ b/backend/parsers/parser_docx.py
@@ -48,6 +48,7 @@ def _parse_vak_from_filename(filename: str) -> Optional[str]:
     base = filename.rsplit(".", 1)[0]
     part = base.split("_")[0]
     part = re.sub(r"\d+", "", part)  # verwijder cijfers
+    part = re.sub(r"(?i)studiewijzer|periode", "", part)  # verwijder generieke woorden
     part = part.replace("-", " ").strip()
     return part or None
 
@@ -158,6 +159,10 @@ def _weeks_from_week_cell(txt: str) -> List[int]:
     - Puur getal als hele cel
     """
     text = (txt or "").strip().replace("\n", " ")
+
+    # Verwijder datums zoals 25-08-2025 zodat RE_WEEK_PAIR hieronder
+    # niet per ongeluk dagen/maanden als weken herkent.
+    text = re.sub(r"\b\d{1,2}\s*[-/]\s*\d{1,2}\s*[-/]\s*\d{2,4}\b", " ", text)
 
     weeks: List[int] = []
 

--- a/backend/parsers/parser_pdf.py
+++ b/backend/parsers/parser_pdf.py
@@ -17,19 +17,23 @@ def extract_meta_from_pdf(path: str, filename: str) -> DocMeta:
     begin_week, eind_week = 36, 41
 
     def weeks_from_text(txt: str):
+        # Verwijder datums (bijv. 25-08-2025) zodat we geen dag/maand als week
+        # interpreteren.
+        clean = re.sub(r"\b\d{1,2}\s*[-/]\s*\d{1,2}\s*[-/]\s*\d{2,4}\b", " ", txt)
+
         weeks = []
-        for a, b in RE_WEEK_PAIR.findall(txt):
+        for a, b in RE_WEEK_PAIR.findall(clean):
             for x in (a, b):
                 v = int(x)
                 if 1 <= v <= 53:
                     weeks.append(v)
-        for x in RE_WEEK_SOLO.findall(txt):
+        for x in RE_WEEK_SOLO.findall(clean):
             v = int(x)
             if 1 <= v <= 53:
                 weeks.append(v)
         if not weeks:
-            has_year = bool(re.search(r"20\d{2}", txt))
-            nums = [int(n) for n in re.findall(r"\b(\d{1,2})\b", txt)]
+            has_year = bool(re.search(r"20\d{2}", clean))
+            nums = [int(n) for n in re.findall(r"\b(\d{1,2})\b", clean)]
             nums = [n for n in nums if 1 <= n <= 53]
             if nums:
                 hi = [n for n in nums if n >= 30]


### PR DESCRIPTION
## Summary
- ignore date patterns when extracting week numbers from DOCX/PDF schedules
- drop generic terms from filenames for better subject detection

## Testing
- `python ./tools/parse_demo.py ./samples/Aardrijkskunde_4V_P1_2025-2026.docx`
- `python ./tools/parse_demo.py ./samples/Duits_4V_P1_2025-2026.docx`
- `python ./tools/parse_demo.py './samples/Frans Studiewijzer 25-26 periode 1.docx'`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c735eb8fa0832286f463f844eff4cc