### PR TITLE
Add DocRow model and row parsing for planners

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional
+from typing import Literal, Optional, List, Dict
 from pydantic import BaseModel
 
 # Gebruik een eenduidige naam
@@ -23,3 +23,19 @@ class WeekItem(BaseModel):
     deadlines: Optional[str] = None
     opmerkingen: Optional[str] = None
     date: Optional[str] = None        # ISO "YYYY-MM-DD"
+
+
+class DocRow(BaseModel):
+    week: Optional[int]
+    datum: Optional[str]
+    les: Optional[str]
+    onderwerp: Optional[str]
+    leerdoelen: Optional[List[str]]
+    huiswerk: Optional[str]
+    opdracht: Optional[str]
+    inleverdatum: Optional[str]
+    toets: Optional[Dict[str, Optional[str]]]
+    bronnen: Optional[List[Dict[str, str]]]
+    notities: Optional[str]
+    klas_of_groep: Optional[str]
+    locatie: Optional[str]

--- a/backend/parsers/__init__.py
+++ b/backend/parsers/__init__.py
@@ -1,3 +1,7 @@
 # eenvoudige re-export, met absolute imports intern
-from .parser_docx import extract_meta_from_docx
-from .parser_pdf import extract_meta_from_pdf
+from .parser_docx import extract_meta_from_docx, extract_rows_from_docx
+
+try:  # pragma: no cover
+    from .parser_pdf import extract_meta_from_pdf, extract_rows_from_pdf
+except Exception:  # pdfplumber kan ontbreken
+    extract_meta_from_pdf = extract_rows_from_pdf = None  # type: ignore


### PR DESCRIPTION
## Summary
- introduce `DocRow` model for row-level information
- parse rows from DOCX and PDF files, duplicating week pairs and capturing homework, tests and resources
- extend CLI demo with `--rows` flag to output both metadata and row details

## Testing
- `python -m py_compile backend/models.py backend/parsers/__init__.py backend/parsers/parser_docx.py backend/parsers/parser_pdf.py tools/parse_demo.py`
- `python tools/parse_demo.py samples/Aardrijkskunde_4V_P1_2025-2026.docx --rows` *(fails for PDF samples: pdfplumber not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c7452408d88322b268ef2c928a4e31