### PR TITLE
Fix PDF week parsing and add PyPDF2 fallback

### DIFF
--- a/backend/parsers/parser_pdf.py
+++ b/backend/parsers/parser_pdf.py
@@ -1,6 +1,24 @@
-import pdfplumber
+"""PDF parsing utilities.
+
+Deze module probeert eerst `pdfplumber` te gebruiken voor het uitlezen van
+PDF-bestanden. Als dat pakket niet beschikbaar is, valt het terug op
+`PyPDF2`. Hierdoor blijven de hulpscripts werken zonder extra
+installatiestap, al levert `pdfplumber` doorgaans betere resultaten op.
+"""
+
 import re
-from typing import List
+from typing import Generator, List, Tuple
+
+try:  # pdfplumber levert vaak de beste tekstextractie
+    import pdfplumber  # type: ignore
+except Exception:  # pragma: no cover - optionele dependency
+    pdfplumber = None  # type: ignore
+
+try:  # eenvoudige fallback wanneer pdfplumber ontbreekt
+    from PyPDF2 import PdfReader  # type: ignore
+except Exception:  # pragma: no cover - PyPDF2 kan ontbreken
+    PdfReader = None  # type: ignore
+
 from models import DocMeta, DocRow
 
 RE_ANY_BRACKET_VAK = re.compile(r"\[\s*([A-Za-zÀ-ÿ\s\-\&]+?)\s*\]")
@@ -18,7 +36,12 @@ def extract_meta_from_pdf(path: str, filename: str) -> DocMeta:
     # Default weeks are 0 so that we don't fall back to a fixed range
     begin_week, eind_week = 0, 0
 
-    def weeks_from_text(txt: str):
+    def weeks_from_text(txt: str, page_num: int, total_pages: int):
+        # Verwijder paginanummers zoals "9/46" of "9-46" zodat deze niet als
+        # weekrange worden geïnterpreteerd.
+        page_pat = rf"\b{page_num}\s*[/\-]\s*{total_pages}\b"
+        txt = re.sub(page_pat, " ", txt)
+
         # Verwijder datums (bijv. 25-08-2025) zodat we geen dag/maand als week
         # interpreteren.
         clean = re.sub(r"\b\d{1,2}\s*[-/]\s*\d{1,2}\s*[-/]\s*\d{2,4}\b", " ", txt)
@@ -41,45 +64,45 @@ def extract_meta_from_pdf(path: str, filename: str) -> DocMeta:
                 weeks.extend(nums)
         return weeks
 
-    with pdfplumber.open(path) as pdf:
-        first_text = (pdf.pages[0].extract_text() or "") if pdf.pages else ""
+    pages = list(_page_texts(path))
+    first_text = pages[0][2] if pages else ""
 
-        m = RE_ANY_BRACKET_VAK.search(first_text)
+    m = RE_ANY_BRACKET_VAK.search(first_text)
+    if m:
+        vak = m.group(1).strip()
+    else:
+        m = RE_AFTER_DASH.search(first_text)
         if m:
             vak = m.group(1).strip()
         else:
-            m = RE_AFTER_DASH.search(first_text)
-            if m:
-                vak = m.group(1).strip()
-            else:
-                base = filename.rsplit(".", 1)[0]
-                part = base.split("_")[0]
-                part = re.sub(r"\d+", "", part).replace("-", " ").strip()
-                if part:
-                    vak = part
+            base = filename.rsplit(".", 1)[0]
+            part = base.split("_")[0]
+            part = re.sub(r"\d+", "", part).replace("-", " ").strip()
+            if part:
+                vak = part
 
-        m = re.search(r"(20\d{2}/20\d{2})", first_text)
-        if m:
-            schooljaar = m.group(1)
+    m = re.search(r"(20\d{2}/20\d{2})", first_text)
+    if m:
+        schooljaar = m.group(1)
 
-        ft = first_text.lower()
-        if "havo" in ft:
-            niveau = "HAVO"
-        if "vwo" in ft:
-            niveau = "VWO"
-        m = re.search(r"\b([1-6])\b", ft)
-        if m:
-            leerjaar = m.group(1)
-        m = re.search(r"periode\s*([1-4])", ft)
-        if m:
-            periode = int(m.group(1))
+    ft = first_text.lower()
+    if "havo" in ft:
+        niveau = "HAVO"
+    if "vwo" in ft:
+        niveau = "VWO"
+    m = re.search(r"\b([1-6])\b", ft)
+    if m:
+        leerjaar = m.group(1)
+    m = re.search(r"periode\s*([1-4])", ft)
+    if m:
+        periode = int(m.group(1))
 
-        weeks = []
-        for page in pdf.pages:
-            txt = page.extract_text() or ""
-            weeks += weeks_from_text(txt)
-        if weeks:
-            begin_week, eind_week = min(weeks), max(weeks)
+    total_pages = pages[0][1] if pages else 0
+    weeks: List[int] = []
+    for idx, _, txt in pages:
+        weeks += weeks_from_text(txt, idx, total_pages)
+    if weeks:
+        begin_week, eind_week = min(weeks), max(weeks)
 
     file_id = re.sub(r"[^a-zA-Z0-9]+", "-", filename)[:40]
     return DocMeta(
@@ -104,22 +127,65 @@ def _normalize(text: str) -> str:
 
 def extract_rows_from_pdf(path: str, filename: str) -> List[DocRow]:
     rows: List[DocRow] = []
-    with pdfplumber.open(path) as pdf:
-        for page in pdf.pages:
-            txt = page.extract_text() or ""
-            for line in txt.splitlines():
-                m = RE_WEEK_LEADING.match(line)
-                if not m:
-                    continue
-                weeks: List[int] = []
-                a = int(m.group(1))
-                if 1 <= a <= 53:
-                    weeks.append(a)
-                if m.group(2):
-                    b = int(m.group(2))
-                    if 1 <= b <= 53:
-                        weeks.append(b)
-                rest = _normalize(line[m.end():])
-                for w in weeks:
-                    rows.append(DocRow(week=w, onderwerp=rest or None))
+    for idx, total_pages, txt in _page_texts(path):
+        page_pat = re.compile(rf"^\s*{idx}\s*[/\-]\s*{total_pages}\s*$")
+        for line in txt.splitlines():
+            if page_pat.match(line):
+                continue
+            m = RE_WEEK_LEADING.match(line)
+            if not m:
+                continue
+            weeks: List[int] = []
+            a = int(m.group(1))
+            if 1 <= a <= 53:
+                weeks.append(a)
+            if m.group(2):
+                b = int(m.group(2))
+                if 1 <= b <= 53:
+                    weeks.append(b)
+            rest = _normalize(line[m.end():])
+            for w in weeks:
+                rows.append(
+                    DocRow(
+                        week=w,
+                        datum=None,
+                        les=None,
+                        onderwerp=rest or None,
+                        leerdoelen=None,
+                        huiswerk=None,
+                        opdracht=None,
+                        inleverdatum=None,
+                        toets=None,
+                        bronnen=None,
+                        notities=None,
+                        klas_of_groep=None,
+                        locatie=None,
+                    )
+                )
     return rows
+
+
+def _page_texts(path: str) -> Generator[Tuple[int, int, str], None, None]:
+    """Yields (page_number, total_pages, text) tuples.
+
+    Gebruikt pdfplumber als dat aanwezig is; anders valt het terug op PyPDF2.
+    Als beide ontbreken wordt een RuntimeError opgegooid.
+    """
+
+    if pdfplumber is not None:  # voorkeursoptie
+        with pdfplumber.open(path) as pdf:  # type: ignore[arg-type]
+            total_pages = len(pdf.pages)
+            for idx, page in enumerate(pdf.pages, start=1):
+                yield idx, total_pages, page.extract_text() or ""
+        return
+
+    if PdfReader is not None:  # eenvoudige fallback
+        reader = PdfReader(path)
+        total_pages = len(reader.pages)
+        for idx, page in enumerate(reader.pages, start=1):
+            # PyPDF2's extract_text kan None retourneren
+            txt = page.extract_text() or ""
+            yield idx, total_pages, txt
+        return
+
+    raise RuntimeError("PDF-ondersteuning ontbreekt (pdfplumber/PyPDF2 niet geïnstalleerd)")

--- a/tools/README.md
+++ b/tools/README.md
@@ -2,7 +2,21 @@
 
 Gebruik dit hulpscript om DOCX/PDF studiewijzers te parsen buiten de server.
 
-Windows (PowerShell):
+Voor PDF's wordt standaard geprobeerd `pdfplumber` te gebruiken. Als dat niet
+geïnstalleerd is, valt het script terug op `PyPDF2`, zodat je ook zonder extra
+packages kunt testen. Installeer `pdfplumber` voor nauwkeurigere
+tekstextractie uit lastig opgemaakte PDF's.
+
+Voorbeelden (PowerShell):
+
 ```powershell
+# Enkel metadata
 python .\tools\parse_demo.py .\samples\Aardrijkskunde_4V_P1_2025-2026.docx
-python .\tools\parse_demo.py .\uploads --json .\tools\out\parse_results.json
+
+# Inclusief rijen als JSON
+python .\tools\parse_demo.py .\uploads --rows --json .\tools\out\parse_results.json
+```
+
+Met de vlag `--rows` (of `--row`) worden ook de tabel-rijen geparsed en als JSON
+teruggegeven.
+

--- a/tools/parse_demo.py
+++ b/tools/parse_demo.py
@@ -21,13 +21,10 @@ from backend.parsers.parser_docx import (
     extract_meta_from_docx,
     extract_rows_from_docx,
 )
-try:
-    from backend.parsers.parser_pdf import (
-        extract_meta_from_pdf,
-        extract_rows_from_pdf,
-    )
-except Exception:  # pragma: no cover - pdf libs kunnen ontbreken
-    extract_meta_from_pdf = extract_rows_from_pdf = None  # type: ignore
+from backend.parsers.parser_pdf import (
+    extract_meta_from_pdf,
+    extract_rows_from_pdf,
+)
 from models import DocMeta, DocRow  # wordt gevonden via BACKEND_DIR op sys.path
 
 
@@ -54,7 +51,7 @@ def main():
     parser = argparse.ArgumentParser(description="Studiewijzer parse demo (PDF/DOCX).")
     parser.add_argument("path", type=str, help="Pad naar bestand of directory")
     parser.add_argument("--json", type=str, default=None, help="Schrijf resultaten naar JSON-bestand")
-    parser.add_argument("--rows", action="store_true", help="Geef ook rijen terug als JSON")
+    parser.add_argument("--rows", "--row", dest="rows", action="store_true", help="Geef ook rijen terug als JSON")
     args = parser.parse_args()
 
     src = Path(args.path).resolve()
@@ -72,8 +69,6 @@ def main():
                     meta = extract_meta_from_docx(str(f), f.name)
                     rows = extract_rows_from_docx(str(f), f.name)
                 else:
-                    if extract_meta_from_pdf is None or extract_rows_from_pdf is None:
-                        raise RuntimeError("PDF-ondersteuning ontbreekt (pdfplumber niet geïnstalleerd)")
                     meta = extract_meta_from_pdf(str(f), f.name)
                     rows = extract_rows_from_pdf(str(f), f.name)
                 m_dump = meta.model_dump() if hasattr(meta, "model_dump") else dict(meta)


### PR DESCRIPTION
## Summary
- Ignore PDF pagination when detecting week ranges
- Parse PDFs even without pdfplumber by falling back to PyPDF2
- Simplify parse demo and document the new fallback

## Testing
- `python tools/parse_demo.py samples/Engels_4v_P1_studiewijzer_2526.pdf`
- `python tools/parse_demo.py samples/Engels_4v_P1_studiewijzer_2526.pdf --row | head -n 20`
- `python tools/parse_demo.py samples/Aardrijkskunde_4V_P1_2025-2026.docx --row | head -n 20`
- `python -m py_compile backend/parsers/parser_pdf.py tools/parse_demo.py`


------
https://chatgpt.com/codex/tasks/task_e_68c74d1873b883228bbbaaceffe7d98f