### PR TITLE
Add Deadlines view updates and document preview support

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,9 +1,18 @@
 from fastapi import FastAPI, UploadFile, File, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
 from typing import List
 from pathlib import Path
+import mimetypes
 import shutil
 import uuid
+from html import escape
+
+from docx import Document
+from docx.oxml.table import CT_Tbl
+from docx.oxml.text.paragraph import CT_P
+from docx.table import Table
+from docx.text.paragraph import Paragraph
 
 from models import DocMeta  # jij gebruikt nog models.py; laat dit zo staan
 from parsers import extract_meta_from_docx, extract_meta_from_pdf
@@ -28,6 +37,42 @@ DOCS: dict[str, DocMeta] = {}
 # -----------------------------
 # Endpoints
 # -----------------------------
+
+def _iter_docx_blocks(document: Document):
+    body = document.element.body
+    for child in body.iterchildren():
+        if isinstance(child, CT_P):
+            yield Paragraph(child, document)
+        elif isinstance(child, CT_Tbl):
+            yield Table(child, document)
+
+
+def _docx_to_html(path: Path) -> str:
+    try:
+        doc = Document(str(path))
+    except Exception as exc:  # pragma: no cover - afhankelijk van docx lib
+        raise HTTPException(500, f"Kon document niet openen: {exc}")
+
+    parts: list[str] = []
+    for block in _iter_docx_blocks(doc):
+        if isinstance(block, Paragraph):
+            text = escape(block.text or "").replace("\n", "<br/>")
+            parts.append(f"<p>{text or '&nbsp;'}</p>")
+        elif isinstance(block, Table):
+            rows_html: list[str] = []
+            for row in block.rows:
+                cells_html = []
+                for cell in row.cells:
+                    cell_text = escape(cell.text or "").replace("\n", "<br/>")
+                    cells_html.append(f"<td>{cell_text or '&nbsp;'}</td>")
+                rows_html.append(f"<tr>{''.join(cells_html)}</tr>")
+            parts.append(
+                "<table class=\"docx-table\">{}</table>".format("".join(rows_html))
+            )
+    if not parts:
+        return "<p><em>Geen tekstinhoud gevonden in document.</em></p>"
+    return "".join(parts)
+
 
 @app.get("/api/docs", response_model=List[DocMeta])
 def list_docs():
@@ -56,6 +101,61 @@ def delete_all_docs():
         except Exception:
             pass
     return {"ok": True}
+
+
+@app.get("/api/docs/{file_id}/content")
+def get_doc_content(file_id: str):
+    doc = DOCS.get(file_id)
+    if not doc:
+        raise HTTPException(404, "Not found")
+
+    suffix = Path(doc.bestand).suffix.lower()
+    file_path = STORAGE / f"{file_id}{suffix}"
+    if not file_path.exists():
+        # fallback: zoek naar willekeurige match voor het geval de suffix verschilt
+        match = next(STORAGE.glob(f"{file_id}.*"), None)
+        if not match or not match.exists():
+            raise HTTPException(404, "File missing")
+        file_path = match
+        suffix = file_path.suffix.lower()
+
+    media_type, _ = mimetypes.guess_type(file_path.name)
+    return FileResponse(
+        file_path,
+        media_type=media_type or "application/octet-stream",
+        filename=doc.bestand,
+    )
+
+
+@app.get("/api/docs/{file_id}/preview")
+def get_doc_preview(file_id: str):
+    doc = DOCS.get(file_id)
+    if not doc:
+        raise HTTPException(404, "Not found")
+
+    suffix = Path(doc.bestand).suffix.lower()
+    file_path = STORAGE / f"{file_id}{suffix}"
+    if not file_path.exists():
+        match = next(STORAGE.glob(f"{file_id}.*"), None)
+        if not match or not match.exists():
+            raise HTTPException(404, "File missing")
+        file_path = match
+        suffix = file_path.suffix.lower()
+
+    media_type, _ = mimetypes.guess_type(file_path.name)
+    if suffix == ".docx":
+        html = _docx_to_html(file_path)
+        return {
+            "mediaType": "text/html",
+            "html": html,
+            "filename": doc.bestand,
+        }
+
+    return {
+        "mediaType": media_type or "application/octet-stream",
+        "url": f"/api/docs/{file_id}/content",
+        "filename": doc.bestand,
+    }
 
 @app.post("/api/uploads", response_model=DocMeta)
 async def upload_doc(file: UploadFile = File(...)):

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,10 +3,11 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import AppShell from "./components/layout/AppShell";
 import WeekOverview from "./pages/WeekOverview";
 import Matrix from "./pages/Matrix";
-import Agenda from "./pages/Agenda";
+import Deadlines from "./pages/Deadlines";
 import Uploads from "./pages/Uploads";
 import Settings from "./pages/Settings";
 import { hydrateDocsFromApi } from "./app/store";
+import { DocumentPreviewProvider } from "./components/DocumentPreviewProvider";
 
 export default function App() {
   // Hydrate globale docs-store vanaf de backend zodra de app mount
@@ -16,15 +17,18 @@ export default function App() {
 
   return (
     <BrowserRouter>
-      <AppShell>
-        <Routes>
-          <Route path="/" element={<WeekOverview />} />
-          <Route path="/matrix" element={<Matrix />} />
-          <Route path="/agenda" element={<Agenda />} />
-          <Route path="/uploads" element={<Uploads />} />
-          <Route path="/settings" element={<Settings />} />
-        </Routes>
-      </AppShell>
+      <DocumentPreviewProvider>
+        <AppShell>
+          <Routes>
+            <Route path="/" element={<WeekOverview />} />
+            <Route path="/matrix" element={<Matrix />} />
+            <Route path="/deadlines" element={<Deadlines />} />
+            <Route path="/agenda" element={<Deadlines />} />
+            <Route path="/uploads" element={<Uploads />} />
+            <Route path="/settings" element={<Settings />} />
+          </Routes>
+        </AppShell>
+      </DocumentPreviewProvider>
     </BrowserRouter>
   );
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -9,8 +9,8 @@ async function jsonFetch(url: string, opts?: RequestInit) {
 export const client = {
   getWeeks: (from: string, to: string) =>
     jsonFetch(`${API_URL}/api/weeks?from=${from}&to=${to}`),
-  getAgenda: (week: number, year: number) =>
-    jsonFetch(`${API_URL}/api/agenda?week=${week}&year=${year}`),
+  getDeadlines: (week: number, year: number) =>
+    jsonFetch(`${API_URL}/api/deadlines?week=${week}&year=${year}`),
   getMatrix: (period: number, year: number) =>
     jsonFetch(`${API_URL}/api/matrix?period=${period}&year=${year}`),
   getStudyUnits: () => jsonFetch(`${API_URL}/api/study-units`),

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -13,12 +13,12 @@ export function useWeeks(params: { from: string; to: string }) {
   return { data, error };
 }
 
-export function useAgenda(week: number, year: number) {
+export function useDeadlines(week: number, year: number) {
   const [data, setData] = useState<any[]>([]);
   const [error, setError] = useState<Error | null>(null);
   useEffect(() => {
     client
-      .getAgenda(week, year)
+      .getDeadlines(week, year)
       .then(setData)
       .catch(setError);
   }, [week, year]);

--- a/frontend/src/components/DocumentPreviewProvider.tsx
+++ b/frontend/src/components/DocumentPreviewProvider.tsx
@@ -1,0 +1,158 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { apiGetDocPreview, API_BASE } from "../lib/api";
+
+type DocInfo = { fileId: string; filename: string };
+
+type DocumentPreviewContextValue = {
+  openPreview: (info: DocInfo) => void;
+  closePreview: () => void;
+};
+
+type PreviewState = {
+  mediaType: string;
+  iframeUrl?: string;
+  html?: string;
+};
+
+const DocumentPreviewContext = createContext<DocumentPreviewContextValue | undefined>(
+  undefined
+);
+
+export function DocumentPreviewProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [doc, setDoc] = useState<DocInfo | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [preview, setPreview] = useState<PreviewState | null>(null);
+
+  const closePreview = useCallback(() => {
+    setDoc(null);
+    setLoading(false);
+    setError(null);
+    setPreview(null);
+  }, []);
+
+  useEffect(() => {
+    if (!doc) return;
+    let cancelled = false;
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      setPreview(null);
+      try {
+        const result = await apiGetDocPreview(doc.fileId);
+        if (cancelled) return;
+        if (result.mediaType.includes("html") && result.html) {
+          setPreview({ mediaType: result.mediaType, html: result.html });
+        } else if (result.url) {
+          const iframeUrl = result.url.startsWith("http")
+            ? result.url
+            : `${API_BASE}${result.url}`;
+          setPreview({ mediaType: result.mediaType, iframeUrl });
+        } else {
+          setError("Geen voorvertoning beschikbaar");
+        }
+      } catch (e: any) {
+        if (!cancelled) {
+          setError(e?.message || "Kan document niet laden");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [doc]);
+
+  useEffect(() => {
+    if (!doc) return;
+    const handler = (ev: KeyboardEvent) => {
+      if (ev.key === "Escape") {
+        closePreview();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [doc, closePreview]);
+
+  const openPreview = useCallback((info: DocInfo) => {
+    setDoc(info);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      openPreview,
+      closePreview,
+    }),
+    [openPreview, closePreview]
+  );
+
+  const hasHtml = !!preview?.html;
+
+  return (
+    <DocumentPreviewContext.Provider value={value}>
+      {children}
+      {doc && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div className="absolute inset-0 bg-black/50" onClick={closePreview} />
+          <div className="relative z-10 mx-4 w-full max-w-5xl overflow-hidden rounded-2xl bg-white shadow-xl">
+            <div className="flex items-center justify-between border-b px-5 py-3">
+              <div className="truncate text-sm font-medium" title={doc.filename}>
+                {doc.filename}
+              </div>
+              <button
+                onClick={closePreview}
+                className="rounded-md border px-2 py-1 text-sm"
+                aria-label="Sluiten"
+              >
+                ✕
+              </button>
+            </div>
+            <div className="max-h-[75vh] overflow-auto bg-gray-100">
+              {loading ? (
+                <div className="p-6 text-center text-sm text-gray-600">Bezig met laden…</div>
+              ) : error ? (
+                <div className="p-6 text-sm text-red-600">{error}</div>
+              ) : hasHtml ? (
+                <div
+                  className="prose max-w-none px-6 py-4"
+                  dangerouslySetInnerHTML={{ __html: preview?.html || "" }}
+                />
+              ) : preview?.iframeUrl ? (
+                <iframe
+                  title={doc.filename}
+                  src={preview.iframeUrl}
+                  className="h-[75vh] w-full"
+                />
+              ) : (
+                <div className="p-6 text-sm text-gray-600">Geen voorvertoning beschikbaar.</div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </DocumentPreviewContext.Provider>
+  );
+}
+
+export function useDocumentPreview() {
+  const ctx = useContext(DocumentPreviewContext);
+  if (!ctx) {
+    throw new Error("useDocumentPreview moet binnen DocumentPreviewProvider gebruikt worden");
+  }
+  return ctx;
+}

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -11,7 +11,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
           <nav className="ml-auto flex gap-1">
             <NavLink to="/" className={({isActive}) => `${link} ${isActive?active:"bg-white"}`}>Weekoverzicht</NavLink>
             <NavLink to="/matrix" className={({isActive}) => `${link} ${isActive?active:"bg-white"}`}>Matrix</NavLink>
-            <NavLink to="/agenda" className={({isActive}) => `${link} ${isActive?active:"bg-white"}`}>Agenda</NavLink>
+            <NavLink to="/deadlines" className={({isActive}) => `${link} ${isActive?active:"bg-white"}`}>Deadlines</NavLink>
             <NavLink to="/uploads" className={({isActive}) => `${link} ${isActive?active:"bg-white"}`}>Uploads</NavLink>
             <NavLink to="/settings" className={({isActive}) => `${link} ${isActive?active:"bg-white"}`}>Settings</NavLink>
           </nav>
@@ -23,7 +23,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
         </div>
       </main>
       <footer className="mx-auto max-w-6xl px-4 py-8 text-xs text-gray-500">
-        © {new Date().getFullYear()} Studiewijzer Planner
+        © {new Date().getFullYear()} Studiewijzer Planner - made by Ramon Ankersmit
       </footer>
     </div>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,4 +2,16 @@
 @tailwind components;
 @tailwind utilities;
 
+.docx-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+}
+
+.docx-table td {
+  border: 1px solid #e5e7eb;
+  padding: 0.25rem 0.5rem;
+  vertical-align: top;
+}
+
 body { @apply bg-slate-50 text-slate-800; }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10,7 +10,8 @@ export type DocMeta = {
   schooljaar?: string | null;
 };
 
-const BASE = "http://localhost:8000";
+export const API_BASE = "http://localhost:8000";
+const BASE = API_BASE;
 
 export async function apiListDocs(): Promise<DocMeta[]> {
   const r = await fetch(`${BASE}/api/docs`);
@@ -33,6 +34,21 @@ export async function apiUploadDoc(file: File): Promise<DocMeta> {
   if (!r.ok) {
     const txt = await r.text();
     throw new Error(`upload failed: ${r.status} – ${txt}`);
+  }
+  return r.json();
+}
+
+export type DocPreview = {
+  mediaType: string;
+  url?: string;
+  html?: string;
+  filename?: string;
+};
+
+export async function apiGetDocPreview(fileId: string): Promise<DocPreview> {
+  const r = await fetch(`${BASE}/api/docs/${fileId}/preview`);
+  if (!r.ok) {
+    throw new Error(`preview_doc failed: ${r.status}`);
   }
   return r.json();
 }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -2,10 +2,11 @@ import React from "react";
 import { useAppStore } from "../app/store";
 
 export default function Settings() {
-  const { docs, mijnVakken, setMijnVakken } = useAppStore();
+  const { mijnVakken, setMijnVakken } = useAppStore();
+  const docs = useAppStore((s) => s.docs) ?? [];
 
   const allVakken = React.useMemo(
-    () => Array.from(new Set(docs.map((d) => d.vak))).sort(),
+    () => Array.from(new Set(docs.filter((d) => d.enabled).map((d) => d.vak))).sort(),
     [docs]
   );
 
@@ -28,7 +29,7 @@ export default function Settings() {
         <div className="mb-2 font-medium">Mijn vakken</div>
 
         <div className="mb-3 text-sm text-gray-600">
-          Kies welke vakken zichtbaar zijn in <strong>Weekoverzicht</strong>, <strong>Matrix</strong> en <strong>Agenda</strong>.
+          Kies welke vakken zichtbaar zijn in <strong>Weekoverzicht</strong>, <strong>Matrix</strong> en <strong>Deadlines</strong>.
         </div>
 
         <div className="mb-3 flex gap-2">


### PR DESCRIPTION
## Summary
- add backend preview endpoint that turns DOCX files into HTML and exposes PDF content for embedding
- wire the new DocumentPreviewProvider across the app and rename the Agenda route to Deadlines with data-driven week ranges
- add document enable/disable toggles, multi-upload handling, and preview buttons across Matrix, WeekOverview, and Uploads views

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c86801ea588322bf65a1b764cab407