### PR TITLE
Improve homework tracking and planner labeling

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Studiewijzer Planner</title>
+    <title>Het Vlier Studiewijzer Planner</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -7,7 +7,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
     <div className="min-h-screen bg-gray-50 text-gray-900">
       <header className="sticky top-0 z-20 border-b bg-white/80 backdrop-blur">
         <div className="mx-auto max-w-6xl px-4 py-3 flex items-center gap-3">
-          <div className="text-xl font-semibold">Studiewijzer Planner</div>
+          <div className="text-xl font-semibold">Het Vlier Studiewijzer Planner</div>
           <nav className="ml-auto flex gap-1">
             <NavLink to="/" className={({isActive}) => `${link} ${isActive?active:"bg-white"}`}>Weekoverzicht</NavLink>
             <NavLink to="/matrix" className={({isActive}) => `${link} ${isActive?active:"bg-white"}`}>Matrix</NavLink>
@@ -23,7 +23,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
         </div>
       </main>
       <footer className="mx-auto max-w-6xl px-4 py-8 text-xs text-gray-500">
-        © {new Date().getFullYear()} Studiewijzer Planner - made by Ramon Ankersmit
+        © {new Date().getFullYear()} Het Vlier Studiewijzer Planner - made by Ramon Ankersmit
       </footer>
     </div>
   );

--- a/frontend/src/lib/calendar.ts
+++ b/frontend/src/lib/calendar.ts
@@ -1,0 +1,108 @@
+const ISO_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+const pad2 = (value: number) => value.toString().padStart(2, "0");
+
+export const makeWeekId = (isoYear: number, week: number): string =>
+  `${isoYear}-W${pad2(Math.max(1, Math.min(week, 53)))}`;
+
+export const parseSchoolyearStart = (value?: string | null): number | undefined => {
+  if (!value) return undefined;
+  const match = String(value).match(/\d{4}/);
+  if (!match) return undefined;
+  const yr = Number(match[0]);
+  return Number.isFinite(yr) ? yr : undefined;
+};
+
+export const getIsoWeek = (date: Date): number => {
+  const target = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const dayNum = target.getUTCDay() || 7;
+  target.setUTCDate(target.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(target.getUTCFullYear(), 0, 1));
+  return Math.ceil(((target.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+};
+
+export const getIsoWeekYear = (date: Date): number => {
+  const target = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const dayNum = target.getUTCDay() || 7;
+  target.setUTCDate(target.getUTCDate() + 4 - dayNum);
+  return target.getUTCFullYear();
+};
+
+export const getIsoWeekStart = (isoYear: number, week: number): Date => {
+  const fourthJan = new Date(Date.UTC(isoYear, 0, 4));
+  const fourthDay = fourthJan.getUTCDay() || 7;
+  const monday = new Date(fourthJan);
+  monday.setUTCDate(fourthJan.getUTCDate() - (fourthDay - 1) + (week - 1) * 7);
+  return monday;
+};
+
+export const getIsoWeekEnd = (isoYear: number, week: number): Date => {
+  const start = getIsoWeekStart(isoYear, week);
+  const end = new Date(start);
+  end.setUTCDate(start.getUTCDate() + 6);
+  return end;
+};
+
+export const formatIsoDate = (date: Date): string => {
+  const yr = date.getUTCFullYear();
+  const month = pad2(date.getUTCMonth() + 1);
+  const day = pad2(date.getUTCDate());
+  return `${yr}-${month}-${day}`;
+};
+
+export const parseIsoDate = (value: string | undefined | null): Date | null => {
+  if (!value) return null;
+  const trimmed = value.trim();
+  const match = trimmed.match(ISO_DATE_RE);
+  if (!match) return null;
+  const [, y, m, d] = match;
+  const yr = Number(y);
+  const month = Number(m) - 1;
+  const day = Number(d);
+  if (!Number.isFinite(yr) || !Number.isFinite(month) || !Number.isFinite(day)) return null;
+  const date = new Date(Date.UTC(yr, month, day));
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+const TODAY_UTC = () => {
+  const now = new Date();
+  return new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
+};
+
+export const deriveIsoYearForWeek = (
+  week: number,
+  options: {
+    schooljaar?: string | null;
+    candidateDates?: (string | null | undefined)[];
+    today?: Date;
+  } = {}
+): number => {
+  const { schooljaar, candidateDates = [], today } = options;
+  for (const candidate of candidateDates) {
+    const parsed = parseIsoDate(candidate ?? undefined);
+    if (!parsed) continue;
+    const wk = getIsoWeek(parsed);
+    if (week && wk !== week) continue;
+    return getIsoWeekYear(parsed);
+  }
+
+  const schooljaarStart = parseSchoolyearStart(schooljaar);
+  if (typeof schooljaarStart === "number") {
+    return week >= 30 ? schooljaarStart : schooljaarStart + 1;
+  }
+
+  const base = today ? new Date(Date.UTC(today.getFullYear(), today.getMonth(), today.getDate())) : TODAY_UTC();
+  const baseIsoYear = getIsoWeekYear(base);
+  const candidates = [baseIsoYear - 1, baseIsoYear, baseIsoYear + 1];
+  let bestYear = baseIsoYear;
+  let bestDist = Number.POSITIVE_INFINITY;
+  for (const isoYear of candidates) {
+    const start = getIsoWeekStart(isoYear, week);
+    const dist = Math.abs(start.getTime() - base.getTime());
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestYear = isoYear;
+    }
+  }
+  return bestYear;
+};

--- a/frontend/src/lib/textUtils.ts
+++ b/frontend/src/lib/textUtils.ts
@@ -1,7 +1,45 @@
+const BULLET_RE = /[•●◦▪▫]/g;
+const BASE_SPLIT_RE = /[;\n]/;
+const KEYWORD_SPLITTERS = [
+  /(?=Opgaven\s+\d+)/i,
+  /(?=Opdrachten?\s+\d+)/i,
+  /(?=Par(?:agraaf)?\s+\d+[a-z]?)/i,
+  /(?=Hoofdstuk\s+\d+)/i,
+  /(?=Bl(?:z|ad)\.?\s*\d+)/i,
+  /(?=§\s*\d+)/,
+];
+
 export function splitHomeworkItems(raw?: string | null): string[] {
   if (!raw) return [];
-  return raw
-    .split(/(?:;|\n)/)
+  const sanitized = raw.replace(BULLET_RE, "\n");
+  const initialParts = sanitized
+    .split(BASE_SPLIT_RE)
     .map((part) => part.trim())
     .filter((part) => part.length > 0);
+
+  const expanded = initialParts.flatMap((part) => {
+    let segments = [part];
+    for (const splitter of KEYWORD_SPLITTERS) {
+      segments = segments.flatMap((segment) => {
+        const trimmed = segment.trim();
+        if (!trimmed) return [];
+        const pieces = trimmed.split(splitter).map((piece) => piece.trim()).filter(Boolean);
+        return pieces.length > 1 ? pieces : [trimmed];
+      });
+    }
+    return segments;
+  });
+
+  const normalized = expanded
+    .map((part) => part.replace(/\s+/g, " ").trim())
+    .filter((part) => part.length > 0);
+
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const item of normalized) {
+    if (seen.has(item)) continue;
+    seen.add(item);
+    result.push(item);
+  }
+  return result;
 }

--- a/frontend/src/lib/textUtils.ts
+++ b/frontend/src/lib/textUtils.ts
@@ -1,0 +1,7 @@
+export function splitHomeworkItems(raw?: string | null): string[] {
+  if (!raw) return [];
+  return raw
+    .split(/(?:;|\n)/)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}

--- a/frontend/src/lib/textUtils.ts
+++ b/frontend/src/lib/textUtils.ts
@@ -1,6 +1,7 @@
 const BULLET_RE = /[•●◦▪▫]/g;
 const BASE_SPLIT_RE = /[;\n]/;
 const KEYWORD_PATTERNS = [
+  "Opg\\.?\\s*\\d+(?:\\.\\d+)*[a-z]?",
   "Opgaven\\s+\\d+",
   "Opdrachten?\\s+\\d+",
   "Par(?:agraaf)?\\s+\\d+[a-z]?",

--- a/frontend/src/lib/weekUtils.ts
+++ b/frontend/src/lib/weekUtils.ts
@@ -9,6 +9,20 @@ export const formatRange = (w: WeekInfo) => {
   return `Week ${w.nr}`;
 };
 
+export const formatWeekWindowLabel = (weeks: WeekInfo[]): string => {
+  if (!weeks.length) return "Geen data";
+  const first = weeks[0];
+  const last = weeks[weeks.length - 1];
+  const sameWeek = first.nr === last.nr;
+  const weekLabel = sameWeek ? `Week ${first.nr}` : `Week ${first.nr}–${last.nr}`;
+  const start = first.start || last.start || "";
+  const end = last.end || first.end || "";
+  if (start && end) return `${weekLabel} · ${start} – ${end}`;
+  if (start) return `${weekLabel} · ${start}`;
+  if (end) return `${weekLabel} · ${end}`;
+  return weekLabel;
+};
+
 export const formatHumanDate = (iso?: string) => {
   if (!iso) return "";
   const d = new Date(iso);

--- a/frontend/src/pages/Deadlines.tsx
+++ b/frontend/src/pages/Deadlines.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { CalendarClock, FileText } from "lucide-react";
-import { useAppStore } from "../app/store";
+import { useAppStore, type DocRecord, type WeekInfo } from "../app/store";
 import { formatHumanDate, calcCurrentWeekIdx, formatWeekWindowLabel } from "../lib/weekUtils";
 import { useDocumentPreview } from "../components/DocumentPreviewProvider";
+import { deriveIsoYearForWeek } from "../lib/calendar";
 
 type Item = {
   id: string;
   week: number;
+  isoYear: number;
   type: "Toets" | "Deadline";
   vak: string;
   title: string;
@@ -26,6 +28,18 @@ export default function Deadlines() {
   const [dur, setDur] = React.useState(3);
 
   const activeDocs = React.useMemo(() => docs.filter((d) => d.enabled), [docs]);
+  const docsByVak = React.useMemo(() => {
+    const map = new Map<string, DocRecord[]>();
+    for (const doc of activeDocs) {
+      const list = map.get(doc.vak);
+      if (list) {
+        list.push(doc);
+      } else {
+        map.set(doc.vak, [doc]);
+      }
+    }
+    return map;
+  }, [activeDocs]);
   const hasActiveDocs = activeDocs.length > 0;
   const allWeeks = weekData.weeks ?? [];
   const hasWeekData = allWeeks.length > 0;
@@ -60,26 +74,39 @@ export default function Deadlines() {
     }
   }, [disableWeekControls, goThisWeek]);
 
+  const findDocForWeek = React.useCallback(
+    (vakNaam: string, info: WeekInfo) => {
+      if (!info) return undefined;
+      const docsForVak = docsByVak.get(vakNaam);
+      if (!docsForVak?.length) return undefined;
+      const matched = docsForVak.find((doc) => {
+        const minWeek = Math.min(doc.beginWeek, doc.eindWeek);
+        const maxWeek = Math.max(doc.beginWeek, doc.eindWeek);
+        if (info.nr < minWeek || info.nr > maxWeek) return false;
+        const isoYear = deriveIsoYearForWeek(info.nr, { schooljaar: doc.schooljaar });
+        return isoYear === info.isoYear;
+      });
+      return matched ?? docsForVak[0];
+    },
+    [docsByVak]
+  );
+
   const items: Item[] = !hasUploads
     ? []
     : weeks.flatMap((w) => {
-        const perVak = weekData.byWeek?.[w.nr] || {};
+        const perVak = weekData.byWeek?.[w.id] || {};
         return Object.entries(perVak).flatMap(([vakNaam, d]: any) => {
           if (mijnVakken.length && !mijnVakken.includes(vakNaam)) return [];
           if (vak !== "ALLE" && vakNaam !== vak) return [];
           if (!d?.deadlines || d.deadlines === "—") return [];
           const type: Item["type"] =
             String(d.deadlines).toLowerCase().includes("toets") ? "Toets" : "Deadline";
-          const doc = activeDocs.find(
-            (dd) =>
-              dd.vak === vakNaam &&
-              w.nr >= Math.min(dd.beginWeek, dd.eindWeek) &&
-              w.nr <= Math.max(dd.beginWeek, dd.eindWeek)
-          ) || activeDocs.find((dd) => dd.vak === vakNaam);
+          const doc = findDocForWeek(vakNaam, w);
           return [
             {
-              id: `${vakNaam}-${w.nr}`,
+              id: `${vakNaam}-${w.id}`,
               week: w.nr,
+              isoYear: w.isoYear,
               type,
               vak: vakNaam,
               title: d.deadlines,
@@ -184,7 +211,10 @@ export default function Deadlines() {
                 const dateLabel = it.date ? formatHumanDate(it.date) : "—";
                 return (
                   <tr key={it.id} className={idx > 0 ? "border-t" : ""}>
-                    <td className="px-4 py-2 align-top">wk {it.week}</td>
+                    <td className="px-4 py-2 align-top">
+                      wk {it.week}
+                      <span className="text-xs text-gray-500"> ({it.isoYear})</span>
+                    </td>
                     <td className="px-4 py-2 align-top"><span className="rounded-full border bg-white px-2 py-0.5">{it.type}</span></td>
                     <td className="px-4 py-2 align-top whitespace-nowrap">{it.vak}</td>
                     <td className="px-4 py-2 align-top">{it.title}</td>

--- a/frontend/src/pages/Deadlines.tsx
+++ b/frontend/src/pages/Deadlines.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { CalendarClock, FileText } from "lucide-react";
 import { useAppStore } from "../app/store";
-import { formatHumanDate, calcCurrentWeekIdx, computeWindowStartForWeek } from "../lib/weekUtils";
+import { formatHumanDate, calcCurrentWeekIdx, formatWeekWindowLabel } from "../lib/weekUtils";
 import { useDocumentPreview } from "../components/DocumentPreviewProvider";
 
 type Item = {
@@ -32,9 +32,10 @@ export default function Deadlines() {
   const disableWeekControls = !hasActiveDocs || !hasWeekData;
   const hasUploads = hasActiveDocs && hasWeekData;
 
-  const maxFrom = Math.max(0, allWeeks.length - dur);
-  const clampedFrom = Math.min(fromIdx, maxFrom);
+  const maxStartIdx = Math.max(0, allWeeks.length - 1);
+  const clampedFrom = Math.min(fromIdx, maxStartIdx);
   const weeks = allWeeks.slice(clampedFrom, clampedFrom + dur);
+  const windowLabel = formatWeekWindowLabel(weeks);
 
   const prev = () => {
     if (disableWeekControls) return;
@@ -42,15 +43,13 @@ export default function Deadlines() {
   };
   const next = () => {
     if (disableWeekControls) return;
-    setFromIdx((i) => Math.min(maxFrom, i + 1));
+    setFromIdx((i) => Math.min(maxStartIdx, i + 1));
   };
   const goThisWeek = React.useCallback(() => {
     if (disableWeekControls) return;
     const idx = calcCurrentWeekIdx(allWeeks);
-    const currentWeekNr = allWeeks[idx]?.nr;
-    const start = computeWindowStartForWeek(allWeeks, dur, currentWeekNr);
-    setFromIdx(start);
-  }, [allWeeks, dur, disableWeekControls]);
+    setFromIdx(idx);
+  }, [allWeeks, disableWeekControls]);
 
   // >>> Eerste load: centreer venster rond huidige week
   React.useEffect(() => {
@@ -95,6 +94,8 @@ export default function Deadlines() {
   return (
     <div>
       <div className="text-lg font-semibold mb-3">Deadlines</div>
+
+      <div className="mb-2 text-sm text-gray-600">{windowLabel}</div>
 
       <div className="mb-3 flex flex-wrap items-center gap-2">
         <button

--- a/frontend/src/pages/Matrix.tsx
+++ b/frontend/src/pages/Matrix.tsx
@@ -299,7 +299,10 @@ export default function Matrix() {
 
   return (
     <div>
-      <div className="mb-2 text-sm text-gray-600">{windowLabel}</div>
+      <div className="mb-4">
+        <h1 className="text-lg font-semibold">Matrix</h1>
+        <div className="mt-1 text-sm text-gray-600">{windowLabel}</div>
+      </div>
       <div className="mb-4 flex flex-wrap gap-2 items-center">
         <button
           onClick={goThisWeek}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useAppStore } from "../app/store";
 
 export default function Settings() {
-  const { mijnVakken, setMijnVakken } = useAppStore();
+  const { mijnVakken, setMijnVakken, huiswerkWeergave, setHuiswerkWeergave } = useAppStore();
   const docs = useAppStore((s) => s.docs) ?? [];
 
   const allVakken = React.useMemo(
@@ -52,6 +52,37 @@ export default function Settings() {
 
         <div className="mt-4 text-xs text-gray-500">
           Deze lijst volgt automatisch de geüploade documenten.
+        </div>
+      </div>
+
+      <div className="rounded-2xl border bg-white p-4">
+        <div className="mb-2 font-medium">Huiswerkweergave</div>
+
+        <div className="mb-3 text-sm text-gray-600">
+          Kies hoe huiswerk wordt getoond in <strong>Weekoverzicht</strong> en <strong>Matrix</strong>.
+        </div>
+
+        <div className="space-y-2 text-sm">
+          <label className="flex items-center gap-2 rounded-md border p-2 bg-white">
+            <input
+              type="radio"
+              name="huiswerkweergave"
+              value="perOpdracht"
+              checked={huiswerkWeergave === "perOpdracht"}
+              onChange={() => setHuiswerkWeergave("perOpdracht")}
+            />
+            <span>Per opdracht (meerdere regels met vinkjes)</span>
+          </label>
+          <label className="flex items-center gap-2 rounded-md border p-2 bg-white">
+            <input
+              type="radio"
+              name="huiswerkweergave"
+              value="gecombineerd"
+              checked={huiswerkWeergave === "gecombineerd"}
+              onChange={() => setHuiswerkWeergave("gecombineerd")}
+            />
+            <span>Alles als één regel met één vinkje</span>
+          </label>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/Uploads.tsx
+++ b/frontend/src/pages/Uploads.tsx
@@ -313,8 +313,6 @@ export default function Uploads() {
               Bereik: week {detailDoc.beginWeek} – {detailDoc.eindWeek}
               {"\n"}
               Schooljaar: {detailDoc.schooljaar || "—"}
-              {"\n\n"}
-              Let op: deze metadata voedt de filters en views (Weekoverzicht/Matrix/Deadlines).
             </div>
           </div>
         </div>

--- a/frontend/src/pages/WeekOverview.tsx
+++ b/frontend/src/pages/WeekOverview.tsx
@@ -309,8 +309,11 @@ export default function WeekOverview() {
 
   return (
     <div>
-      <div className="mb-2 text-sm text-gray-600">
-        Week {week?.nr ?? "—"} · {week ? formatRange(week) : "Geen data"}
+      <div className="mb-4">
+        <h1 className="text-lg font-semibold">Weekoverzicht</h1>
+        <div className="mt-1 text-sm text-gray-600">
+          Week {week?.nr ?? "—"} · {week ? formatRange(week) : "Geen data"}
+        </div>
       </div>
 
       <div className="mb-4 flex flex-wrap gap-2 items-center">

--- a/tools/parse_demo.py
+++ b/tools/parse_demo.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Parser demo CLI voor Studiewijzer Planner
+Parser demo CLI voor Het Vlier Studiewijzer Planner
 """
 
 import argparse
@@ -48,7 +48,7 @@ def print_result(meta: DocMeta):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Studiewijzer parse demo (PDF/DOCX).")
+    parser = argparse.ArgumentParser(description="Het Vlier Studiewijzer parse demo (PDF/DOCX).")
     parser.add_argument("path", type=str, help="Pad naar bestand of directory")
     parser.add_argument("--json", type=str, default=None, help="Schrijf resultaten naar JSON-bestand")
     parser.add_argument("--rows", "--row", dest="rows", action="store_true", help="Geef ook rijen terug als JSON")


### PR DESCRIPTION
## Summary
- rename the interface to “Het Vlier Studiewijzer Planner” and drop the metadata warning in the uploads modal
- normalise vak labels to start with a capital and split homework strings into individually checkable items shared with the matrix view
- add reusable week range labelling for matrix/deadline views and ensure the deadlines jump button starts at the current week

## Testing
- `npm run build` *(fails: rollup optional dependency @rollup/rollup-linux-x64-gnu missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b650c4f08322b70f34f7448acc1f