### PR TITLE
Add configurable theme and background options

### DIFF
--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -33,6 +33,26 @@ export type WeekAggregation = {
   byWeek: Record<string, Record<string, WeekData>>;
 };
 
+export type ThemeSettings = {
+  background: string;
+  surface: string;
+  accent: string;
+  text: string;
+  muted: string;
+  border: string;
+  accentText: string;
+};
+
+const defaultTheme: ThemeSettings = {
+  background: "#f8fafc",
+  surface: "#ffffff",
+  accent: "#111827",
+  text: "#0f172a",
+  muted: "#64748b",
+  border: "#e2e8f0",
+  accentText: "#ffffff",
+};
+
 type State = {
   // ==== documenten (globaal) ====
   docs: DocRecord[];
@@ -51,6 +71,12 @@ type State = {
   setMijnVakken: (v: string[]) => void;
   huiswerkWeergave: "perOpdracht" | "gecombineerd";
   setHuiswerkWeergave: (mode: "perOpdracht" | "gecombineerd") => void;
+  theme: ThemeSettings;
+  setThemeColor: (key: keyof ThemeSettings, value: string) => void;
+  resetTheme: () => void;
+  backgroundImage: string | null;
+  setBackgroundImage: (value: string | null) => void;
+  resetBackgroundImage: () => void;
 
   // ==== afvinkstatus gedeeld ====
   doneMap: Record<string, boolean>;
@@ -391,6 +417,13 @@ export const useAppStore = create<State>((set, get) => ({
   setMijnVakken: (v) => set({ mijnVakken: v }),
   huiswerkWeergave: "perOpdracht",
   setHuiswerkWeergave: (mode) => set({ huiswerkWeergave: mode }),
+  theme: { ...defaultTheme },
+  setThemeColor: (key, value) =>
+    set((state) => ({ theme: { ...state.theme, [key]: value } })),
+  resetTheme: () => set({ theme: { ...defaultTheme } }),
+  backgroundImage: null,
+  setBackgroundImage: (value) => set({ backgroundImage: value }),
+  resetBackgroundImage: () => set({ backgroundImage: null }),
 
   // ----------------------------
   // done-map

--- a/frontend/src/components/DocumentPreviewProvider.tsx
+++ b/frontend/src/components/DocumentPreviewProvider.tsx
@@ -109,22 +109,22 @@ export function DocumentPreviewProvider({
       {doc && (
         <div className="fixed inset-0 z-50 flex items-center justify-center">
           <div className="absolute inset-0 bg-black/50" onClick={closePreview} />
-          <div className="relative z-10 mx-4 w-full max-w-5xl overflow-hidden rounded-2xl bg-white shadow-xl">
-            <div className="flex items-center justify-between border-b px-5 py-3">
+          <div className="relative z-10 mx-4 w-full max-w-5xl overflow-hidden rounded-2xl border theme-border theme-surface shadow-xl">
+            <div className="flex items-center justify-between border-b theme-border px-5 py-3">
               <div className="truncate text-sm font-medium" title={doc.filename}>
                 {doc.filename}
               </div>
               <button
                 onClick={closePreview}
-                className="rounded-md border px-2 py-1 text-sm"
+                className="rounded-md border theme-border theme-surface px-2 py-1 text-sm"
                 aria-label="Sluiten"
               >
                 ✕
               </button>
             </div>
-            <div className="max-h-[75vh] overflow-auto bg-gray-100">
+            <div className="max-h-[75vh] overflow-auto theme-soft">
               {loading ? (
-                <div className="p-6 text-center text-sm text-gray-600">Bezig met laden…</div>
+                <div className="p-6 text-center text-sm theme-muted">Bezig met laden…</div>
               ) : error ? (
                 <div className="p-6 text-sm text-red-600">{error}</div>
               ) : hasHtml ? (
@@ -139,7 +139,7 @@ export function DocumentPreviewProvider({
                   className="h-[75vh] w-full"
                 />
               ) : (
-                <div className="p-6 text-sm text-gray-600">Geen voorvertoning beschikbaar.</div>
+                <div className="p-6 text-sm theme-muted">Geen voorvertoning beschikbaar.</div>
               )}
             </div>
           </div>

--- a/frontend/src/components/SubjectWeekView.jsx
+++ b/frontend/src/components/SubjectWeekView.jsx
@@ -17,16 +17,16 @@ export default function SubjectWeekView({ tasks }) {
   return (
     <div className="space-y-4">
       {subjects.map(subj => (
-        <div key={subj} className="bg-white rounded-2xl shadow p-4">
+        <div key={subj} className="rounded-2xl border theme-border theme-surface shadow p-4">
           <div className="font-semibold mb-2">{subj}</div>
           <ul className="space-y-2">
             {bySubject[subj].sort((a,b)=>a.datum.localeCompare(b.datum)).map(it => (
               <li key={it.id || it.vak+it.titel+it.datum} className="flex items-start gap-2">
-                <span className="text-xs text-slate-500 w-16">{fmt(it.datum)}</span>
+                <span className="text-xs theme-muted w-16">{fmt(it.datum)}</span>
                 <div className="text-sm">
                   <div className="font-medium">{it.titel}</div>
                   {it.is_assessment && <div className="text-xs text-red-700">TOETS / DEADLINE</div>}
-                  {it.omschrijving && <div className="text-xs text-slate-600">{it.omschrijving}</div>}
+                  {it.omschrijving && <div className="text-xs theme-muted">{it.omschrijving}</div>}
                 </div>
               </li>
             ))}

--- a/frontend/src/components/ViewToggle.jsx
+++ b/frontend/src/components/ViewToggle.jsx
@@ -7,12 +7,12 @@ export default function ViewToggle({ view, setView }) {
     { id:'subject', label:'Per vak' },
   ]
   return (
-    <div className="inline-flex rounded-xl border border-slate-200 bg-white overflow-hidden">
-      {opts.map(o => (
+    <div className="inline-flex rounded-xl border theme-border overflow-hidden">
+      {opts.map((o) => (
         <button
           key={o.id}
-          onClick={()=>setView(o.id)}
-          className={(view===o.id?'bg-slate-900 text-white':'text-slate-700') + ' px-3 py-1.5 text-sm'}
+          onClick={() => setView(o.id)}
+          className={`${view === o.id ? 'theme-accent' : 'theme-surface theme-text'} px-3 py-1.5 text-sm transition-colors`}
         >
           {o.label}
         </button>

--- a/frontend/src/components/WeekListView.jsx
+++ b/frontend/src/components/WeekListView.jsx
@@ -17,8 +17,8 @@ export default function WeekListView({ tasks }) {
   return (
     <div className="space-y-4">
       {dates.map(d => (
-        <div key={d} className="bg-white rounded-2xl shadow p-4">
-          <div className="font-semibold text-sm uppercase text-slate-600 mb-2">{fmt(d)}</div>
+        <div key={d} className="rounded-2xl border theme-border theme-surface shadow p-4">
+          <div className="font-semibold text-sm uppercase theme-muted mb-2">{fmt(d)}</div>
           <ul className="space-y-2">
             {byDate[d].map(it => (
               <li key={it.id || it.vak+it.titel+it.datum} className="flex items-start gap-2">
@@ -26,7 +26,7 @@ export default function WeekListView({ tasks }) {
                 <div className="text-sm">
                   <div className="font-medium">{it.titel}</div>
                   {it.is_assessment && <div className="text-xs text-red-700">TOETS / DEADLINE</div>}
-                  {it.omschrijving && <div className="text-xs text-slate-600">{it.omschrijving}</div>}
+                  {it.omschrijving && <div className="text-xs theme-muted">{it.omschrijving}</div>}
                 </div>
               </li>
             ))}

--- a/frontend/src/components/WeekView.jsx
+++ b/frontend/src/components/WeekView.jsx
@@ -18,17 +18,17 @@ export default function WeekView({ tasks, week }) {
       {days.map((d, i) => {
         const items = byDay[Object.keys(mapIdx).find(k => mapIdx[k]===i)] || [];
         return (
-          <div key={i} className="bg-white rounded-2xl shadow p-3">
+          <div key={i} className="rounded-2xl border theme-border theme-surface shadow p-3">
             <div className="font-semibold mb-2 uppercase text-sm">{d}</div>
             <div className="space-y-2">
               {items.map(it => (
-                <div key={it.id} className="rounded-xl border border-slate-200 p-3">
+                <div key={it.id} className="rounded-xl border theme-border theme-soft p-3">
                   <div className="flex flex-wrap items-center gap-2 mb-1">
                     <span className="bg-blue-50 text-blue-700 text-xs px-2 py-0.5 rounded-full">{it.vak}</span>
                     {it.is_assessment && <span className="bg-red-50 text-red-700 text-xs px-2 py-0.5 rounded-full">TOETS / DEADLINE</span>}
                   </div>
                   <div className="text-sm font-medium">{it.titel}</div>
-                  {it.omschrijving && <div className="text-xs text-slate-600">{it.omschrijving}</div>}
+                  {it.omschrijving && <div className="text-xs theme-muted">{it.omschrijving}</div>}
                 </div>
               ))}
             </div>

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,28 +1,105 @@
+import React from "react";
 import { NavLink } from "react-router-dom";
+import { useAppStore } from "../../app/store";
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
-  const link = "rounded-md border px-3 py-1 text-sm";
-  const active = "bg-black text-white";
+  const { theme, backgroundImage } = useAppStore((state) => ({
+    theme: state.theme,
+    backgroundImage: state.backgroundImage,
+  }));
+
+  const themeStyle = React.useMemo(() => {
+    const base = {
+      "--app-background": theme.background,
+      "--app-surface": theme.surface,
+      "--app-accent": theme.accent,
+      "--app-text": theme.text,
+      "--app-muted": theme.muted,
+      "--app-border": theme.border,
+      "--app-accent-text": theme.accentText,
+    } as React.CSSProperties;
+    if (backgroundImage) {
+      base.backgroundImage = `url(${backgroundImage})`;
+      base.backgroundSize = "cover";
+      base.backgroundRepeat = "no-repeat";
+      base.backgroundPosition = "center";
+      base.backgroundAttachment = "fixed";
+    } else {
+      base.backgroundImage = "none";
+      base.backgroundSize = "auto";
+      base.backgroundRepeat = "repeat";
+      base.backgroundPosition = "left top";
+      base.backgroundAttachment = "scroll";
+    }
+    return base;
+  }, [theme, backgroundImage]);
+
+  const headerBackground = React.useMemo(() => {
+    if (theme.surface.startsWith("#") && theme.surface.length === 7) {
+      return `${theme.surface}cc`;
+    }
+    return theme.surface;
+  }, [theme.surface]);
+
+  const linkBase = "rounded-md border px-3 py-1 text-sm transition-colors theme-border";
   return (
-    <div className="min-h-screen bg-gray-50 text-gray-900">
-      <header className="sticky top-0 z-20 border-b bg-white/80 backdrop-blur">
+    <div className="min-h-screen theme-app" style={themeStyle}>
+      <header
+        className="sticky top-0 z-20 border-b backdrop-blur theme-border theme-surface"
+        style={{ backgroundColor: headerBackground }}
+      >
         <div className="mx-auto max-w-6xl px-4 py-3 flex items-center gap-3">
-          <div className="text-xl font-semibold">Het Vlier Studiewijzer Planner</div>
+          <div className="text-xl font-semibold theme-text">Het Vlier Studiewijzer Planner</div>
           <nav className="ml-auto flex gap-1">
-            <NavLink to="/" className={({isActive}) => `${link} ${isActive?active:"bg-white"}`}>Weekoverzicht</NavLink>
-            <NavLink to="/matrix" className={({isActive}) => `${link} ${isActive?active:"bg-white"}`}>Matrix</NavLink>
-            <NavLink to="/deadlines" className={({isActive}) => `${link} ${isActive?active:"bg-white"}`}>Deadlines</NavLink>
-            <NavLink to="/uploads" className={({isActive}) => `${link} ${isActive?active:"bg-white"}`}>Uploads</NavLink>
-            <NavLink to="/settings" className={({isActive}) => `${link} ${isActive?active:"bg-white"}`}>Settings</NavLink>
+            <NavLink
+              to="/"
+              className={({ isActive }) =>
+                `${linkBase} ${isActive ? "theme-accent" : "theme-surface theme-text"}`
+              }
+            >
+              Weekoverzicht
+            </NavLink>
+            <NavLink
+              to="/matrix"
+              className={({ isActive }) =>
+                `${linkBase} ${isActive ? "theme-accent" : "theme-surface theme-text"}`
+              }
+            >
+              Matrix
+            </NavLink>
+            <NavLink
+              to="/deadlines"
+              className={({ isActive }) =>
+                `${linkBase} ${isActive ? "theme-accent" : "theme-surface theme-text"}`
+              }
+            >
+              Deadlines
+            </NavLink>
+            <NavLink
+              to="/uploads"
+              className={({ isActive }) =>
+                `${linkBase} ${isActive ? "theme-accent" : "theme-surface theme-text"}`
+              }
+            >
+              Uploads
+            </NavLink>
+            <NavLink
+              to="/settings"
+              className={({ isActive }) =>
+                `${linkBase} ${isActive ? "theme-accent" : "theme-surface theme-text"}`
+              }
+            >
+              Settings
+            </NavLink>
           </nav>
         </div>
       </header>
       <main className="mx-auto max-w-6xl px-4 py-6">
-        <div className="rounded-2xl border bg-white p-6 shadow-sm">
+        <div className="rounded-2xl border theme-border theme-surface p-6 shadow-sm">
           {children}
         </div>
       </main>
-      <footer className="mx-auto max-w-6xl px-4 py-8 text-xs text-gray-500">
+      <footer className="mx-auto max-w-6xl px-4 py-8 text-xs theme-muted">
         © {new Date().getFullYear()} Het Vlier Studiewijzer Planner - made by Ramon Ankersmit
       </footer>
     </div>

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -3,10 +3,8 @@ import { NavLink } from "react-router-dom";
 import { useAppStore } from "../../app/store";
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
-  const { theme, backgroundImage } = useAppStore((state) => ({
-    theme: state.theme,
-    backgroundImage: state.backgroundImage,
-  }));
+  const theme = useAppStore((state) => state.theme);
+  const backgroundImage = useAppStore((state) => state.backgroundImage);
 
   const themeStyle = React.useMemo(() => {
     const base = {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,6 +2,52 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --app-background: #f8fafc;
+  --app-surface: #ffffff;
+  --app-accent: #111827;
+  --app-text: #0f172a;
+  --app-muted: #64748b;
+  --app-border: #e2e8f0;
+  --app-accent-text: #ffffff;
+}
+
+body {
+  background-color: var(--app-background);
+  color: var(--app-text);
+}
+
+.theme-app {
+  background-color: var(--app-background);
+  color: var(--app-text);
+}
+
+.theme-surface {
+  background-color: var(--app-surface);
+  color: var(--app-text);
+}
+
+.theme-soft {
+  background-color: var(--app-background);
+}
+
+.theme-border {
+  border-color: var(--app-border) !important;
+}
+
+.theme-text {
+  color: var(--app-text) !important;
+}
+
+.theme-muted {
+  color: var(--app-muted) !important;
+}
+
+.theme-accent {
+  background-color: var(--app-accent) !important;
+  color: var(--app-accent-text) !important;
+}
+
 .docx-table {
   width: 100%;
   border-collapse: collapse;
@@ -9,9 +55,7 @@
 }
 
 .docx-table td {
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--app-border);
   padding: 0.25rem 0.5rem;
   vertical-align: top;
 }
-
-body { @apply bg-slate-50 text-slate-800; }

--- a/frontend/src/pages/Deadlines.tsx
+++ b/frontend/src/pages/Deadlines.tsx
@@ -120,14 +120,14 @@ export default function Deadlines() {
 
   return (
     <div>
-      <div className="text-lg font-semibold mb-3">Deadlines</div>
+      <div className="text-lg font-semibold mb-3 theme-text">Deadlines</div>
 
-      <div className="mb-2 text-sm text-gray-600">{windowLabel}</div>
+      <div className="mb-2 text-sm theme-muted">{windowLabel}</div>
 
       <div className="mb-3 flex flex-wrap items-center gap-2">
         <button
           onClick={goThisWeek}
-          className="rounded-md border px-2 py-1 text-sm disabled:opacity-40 disabled:cursor-not-allowed"
+          className="rounded-md border theme-border theme-surface px-2 py-1 text-sm disabled:opacity-40 disabled:cursor-not-allowed"
           title="Spring naar huidige week"
           aria-label="Deze week"
           disabled={disableWeekControls}
@@ -136,19 +136,19 @@ export default function Deadlines() {
         </button>
         <button
           onClick={prev}
-          className="rounded-md border px-2 py-1 text-sm disabled:opacity-40 disabled:cursor-not-allowed"
+          className="rounded-md border theme-border theme-surface px-2 py-1 text-sm disabled:opacity-40 disabled:cursor-not-allowed"
           title="Vorige"
           disabled={disableWeekControls}
         >
           ◀
         </button>
-        <span className="text-sm text-gray-800">
+        <span className="text-sm theme-text">
           Week {weeks[0]?.nr ?? "—"}
           {weeks.length > 1 ? `–${weeks[weeks.length - 1].nr}` : ""}
         </span>
         <button
           onClick={next}
-          className="rounded-md border px-2 py-1 text-sm disabled:opacity-40 disabled:cursor-not-allowed"
+          className="rounded-md border theme-border theme-surface px-2 py-1 text-sm disabled:opacity-40 disabled:cursor-not-allowed"
           title="Volgende"
           disabled={disableWeekControls}
         >
@@ -156,7 +156,7 @@ export default function Deadlines() {
         </button>
 
         <select
-          className="rounded-md border px-2 py-1 text-sm"
+          className="rounded-md border theme-border theme-surface px-2 py-1 text-sm"
           value={dur}
           onChange={(e) => setDur(Number(e.target.value))}
           aria-label="Aantal weken tonen"
@@ -169,7 +169,7 @@ export default function Deadlines() {
         </select>
 
         <select
-          className="rounded-md border px-2 py-1 text-sm"
+          className="rounded-md border theme-border theme-surface px-2 py-1 text-sm"
           value={vak}
           onChange={(e) => setVak(e.target.value)}
           aria-label="Filter vak"
@@ -177,13 +177,17 @@ export default function Deadlines() {
           disabled={!hasUploads}
         >
           <option value="ALLE">Alle vakken</option>
-          {mijnVakken.map((v) => <option key={v} value={v}>{v}</option>)}
+          {mijnVakken.map((v) => (
+            <option key={v} value={v}>
+              {v}
+            </option>
+          ))}
         </select>
       </div>
 
-      <div className="overflow-auto rounded-2xl border bg-white">
+      <div className="overflow-auto rounded-2xl border theme-border theme-surface">
         {!hasUploads ? (
-          <div className="p-6 text-sm text-gray-600">
+          <div className="p-6 text-sm theme-muted">
             {hasActiveDocs
               ? "Nog geen weekgegevens beschikbaar. Controleer of de documenten studiewijzerdata bevatten."
               : (
@@ -193,10 +197,10 @@ export default function Deadlines() {
                 )}
           </div>
         ) : items.length === 0 ? (
-          <div className="p-6 text-sm text-gray-600">Geen deadlines in deze periode.</div>
+          <div className="p-6 text-sm theme-muted">Geen deadlines in deze periode.</div>
         ) : (
           <table className="min-w-full text-sm">
-            <thead className="bg-gray-50">
+            <thead className="theme-soft">
               <tr>
                 <th className="px-4 py-2 text-left">Week</th>
                 <th className="px-4 py-2 text-left">Type</th>
@@ -210,18 +214,20 @@ export default function Deadlines() {
               {items.map((it, idx) => {
                 const dateLabel = it.date ? formatHumanDate(it.date) : "—";
                 return (
-                  <tr key={it.id} className={idx > 0 ? "border-t" : ""}>
+                  <tr key={it.id} className={idx > 0 ? "border-t theme-border" : ""}>
                     <td className="px-4 py-2 align-top">
                       wk {it.week}
-                      <span className="text-xs text-gray-500"> ({it.isoYear})</span>
+                      <span className="text-xs theme-muted"> ({it.isoYear})</span>
                     </td>
-                    <td className="px-4 py-2 align-top"><span className="rounded-full border bg-white px-2 py-0.5">{it.type}</span></td>
+                    <td className="px-4 py-2 align-top">
+                      <span className="rounded-full border theme-border theme-surface px-2 py-0.5">{it.type}</span>
+                    </td>
                     <td className="px-4 py-2 align-top whitespace-nowrap">{it.vak}</td>
                     <td className="px-4 py-2 align-top">{it.title}</td>
                     <td className="px-4 py-2 align-top whitespace-nowrap" title={it.date || ""}>{dateLabel}</td>
                     <td className="px-4 py-2 align-top">
                       <button
-                        className="rounded-lg border bg-white p-1 disabled:opacity-40"
+                        className="rounded-lg border theme-border theme-surface p-1 disabled:opacity-40"
                         title={it.src ? `Bron: ${it.src}` : "Geen bron beschikbaar"}
                         aria-label={it.src ? `Bron: ${it.src}` : `Bron niet beschikbaar voor ${it.vak}`}
                         disabled={!it.fileId}

--- a/frontend/src/pages/Matrix.tsx
+++ b/frontend/src/pages/Matrix.tsx
@@ -105,7 +105,7 @@ function MatrixCell({
                             onChange={() => toggleItem(idx)}
                             className="mt-0.5"
                           />
-                          <span className={`flex-1 ${checked ? "line-through text-gray-400" : ""}`}>
+                          <span className={`flex-1 ${checked ? "line-through theme-muted opacity-80" : ""}`}>
                             {item}
                           </span>
                         </label>
@@ -114,7 +114,7 @@ function MatrixCell({
                   })}
                 </ul>
               ) : (
-                <div className="text-gray-500">Geen huiswerk</div>
+                <div className="theme-muted">Geen huiswerk</div>
               )
             ) : aggregatedHomework ? (
               <label className="flex items-start gap-2">
@@ -125,25 +125,25 @@ function MatrixCell({
                   onChange={toggleCombined}
                   className="mt-0.5"
                 />
-                <span className={`flex-1 whitespace-pre-line ${allDone ? "line-through text-gray-400" : ""}`}>
+                <span className={`flex-1 whitespace-pre-line ${allDone ? "line-through theme-muted opacity-80" : ""}`}>
                   {aggregatedHomework}
                 </span>
               </label>
             ) : (
-              <div className="text-gray-500">Geen huiswerk</div>
+              <div className="theme-muted">Geen huiswerk</div>
             )}
           </div>
           <button
             title={doc ? `Bron: ${doc.bestand}` : "Geen bron voor dit vak"}
             aria-label={doc ? `Bron: ${doc.bestand}` : `Geen bron voor ${vak}`}
-            className="text-gray-600 disabled:opacity-40"
+            className="theme-muted disabled:opacity-40"
             disabled={!onOpenDoc}
             onClick={onOpenDoc}
           >
             <FileText size={14} />
           </button>
         </div>
-        <div className={`text-xs text-gray-600 ${allDone ? "opacity-70" : ""}`}>{deadlineLabel}</div>
+        <div className={`text-xs theme-muted ${allDone ? "opacity-80" : ""}`}>{deadlineLabel}</div>
       </div>
     </td>
   );
@@ -300,13 +300,13 @@ export default function Matrix() {
   return (
     <div>
       <div className="mb-4">
-        <h1 className="text-lg font-semibold">Matrix</h1>
-        <div className="mt-1 text-sm text-gray-600">{windowLabel}</div>
+        <h1 className="text-lg font-semibold theme-text">Matrix</h1>
+        <div className="mt-1 text-sm theme-muted">{windowLabel}</div>
       </div>
       <div className="mb-4 flex flex-wrap gap-2 items-center">
         <button
           onClick={goThisWeek}
-          className="rounded-md border px-2 py-1 text-sm disabled:opacity-40 disabled:cursor-not-allowed"
+          className="rounded-md border theme-border theme-surface px-2 py-1 text-sm disabled:opacity-40 disabled:cursor-not-allowed"
           title="Spring naar huidige week"
           aria-label="Deze week"
           disabled={disableWeekControls}
@@ -315,19 +315,19 @@ export default function Matrix() {
         </button>
         <button
           onClick={prev}
-          className="rounded-md border px-2 py-1 text-sm disabled:opacity-40 disabled:cursor-not-allowed"
+          className="rounded-md border theme-border theme-surface px-2 py-1 text-sm disabled:opacity-40 disabled:cursor-not-allowed"
           title="Vorige"
           disabled={disableWeekControls}
         >
           ◀
         </button>
-        <span className="text-sm text-gray-800">
+        <span className="text-sm theme-text">
           Week {weeks[0]?.nr ?? "—"}
           {weeks.length > 1 ? `–${weeks[weeks.length - 1].nr}` : ""}
         </span>
         <button
           onClick={next}
-          className="rounded-md border px-2 py-1 text-sm disabled:opacity-40 disabled:cursor-not-allowed"
+          className="rounded-md border theme-border theme-surface px-2 py-1 text-sm disabled:opacity-40 disabled:cursor-not-allowed"
           title="Volgende"
           disabled={disableWeekControls}
         >
@@ -335,7 +335,7 @@ export default function Matrix() {
         </button>
 
         <select
-          className="rounded-md border px-2 py-1 text-sm"
+          className="rounded-md border theme-border theme-surface px-2 py-1 text-sm"
           value={count}
           onChange={(e) => setCount(Number(e.target.value))}
           aria-label="Aantal weken tonen"
@@ -350,7 +350,7 @@ export default function Matrix() {
         </select>
 
         <select
-          className="rounded-md border px-2 py-1 text-sm"
+          className="rounded-md border theme-border theme-surface px-2 py-1 text-sm"
           value={niveau}
           onChange={(e) => setNiveau(e.target.value as any)}
           aria-label="Filter niveau"
@@ -366,7 +366,7 @@ export default function Matrix() {
         </select>
 
         <select
-          className="rounded-md border px-2 py-1 text-sm"
+          className="rounded-md border theme-border theme-surface px-2 py-1 text-sm"
           value={leerjaar}
           onChange={(e) => setLeerjaar(e.target.value)}
           aria-label="Filter leerjaar"
@@ -383,34 +383,34 @@ export default function Matrix() {
       </div>
 
       {!hasAnyDocs ? (
-        <div className="rounded-2xl border bg-white p-6 text-sm text-gray-600">
+        <div className="rounded-2xl border theme-border theme-surface p-6 text-sm theme-muted">
           Nog geen uploads. Voeg eerst één of meer studiewijzers toe via <strong>Uploads</strong>.
         </div>
       ) : !hasWeekData ? (
-        <div className="rounded-2xl border bg-white p-6 text-sm text-gray-600">
+        <div className="rounded-2xl border theme-border theme-surface p-6 text-sm theme-muted">
           Nog geen weekgegevens beschikbaar. Controleer of de documenten studiewijzerdata bevatten.
         </div>
       ) : showNoDataForFilters ? (
-        <div className="rounded-2xl border bg-white p-6 text-sm text-gray-600">
+        <div className="rounded-2xl border theme-border theme-surface p-6 text-sm theme-muted">
           Geen vakken voor deze filters. Pas de selectie aan of controleer de metadata van de documenten.
         </div>
       ) : (
-        <div className="overflow-auto rounded-2xl border bg-white">
+        <div className="overflow-auto rounded-2xl border theme-border theme-surface">
           <table className="min-w-full text-sm">
-            <thead className="bg-gray-50">
+            <thead className="theme-soft">
               <tr>
                 <th className="px-4 py-2 text-left whitespace-nowrap">Vak</th>
                 {weeks.map((w) => (
                   <th key={w.id} className="px-4 py-2 text-left">
                     <div className="font-medium">Week {w.nr}</div>
-                    <div className="text-xs text-gray-500">{formatRange(w)}</div>
+                    <div className="text-xs theme-muted">{formatRange(w)}</div>
                   </th>
                 ))}
               </tr>
             </thead>
             <tbody>
               {visibleVakken.map((vak) => (
-                <tr key={vak} className="border-t">
+                <tr key={vak} className="border-t theme-border">
                   <td className="px-4 py-2 font-medium whitespace-nowrap">{vak}</td>
                   {weeks.map((w) => {
                     const perWeek = weekData.byWeek?.[w.id] || {};

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,8 +1,19 @@
 import React from "react";
-import { useAppStore } from "../app/store";
+import { useAppStore, type ThemeSettings } from "../app/store";
 
 export default function Settings() {
-  const { mijnVakken, setMijnVakken, huiswerkWeergave, setHuiswerkWeergave } = useAppStore();
+  const {
+    mijnVakken,
+    setMijnVakken,
+    huiswerkWeergave,
+    setHuiswerkWeergave,
+    theme,
+    setThemeColor,
+    resetTheme,
+    backgroundImage,
+    setBackgroundImage,
+    resetBackgroundImage,
+  } = useAppStore();
   const docs = useAppStore((s) => s.docs) ?? [];
 
   const allVakken = React.useMemo(
@@ -21,25 +32,106 @@ export default function Settings() {
   const selectAll = () => setMijnVakken(allVakken);
   const clearAll = () => setMijnVakken([]);
 
+  const colorOptions: { key: keyof ThemeSettings; label: string; description: string }[] = [
+    {
+      key: "background",
+      label: "Achtergrond",
+      description: "Algemene achtergrondkleur van de applicatie.",
+    },
+    {
+      key: "surface",
+      label: "Kaarten & panelen",
+      description: "Gebruikt voor kaarten, tabellen en panelen.",
+    },
+    {
+      key: "text",
+      label: "Tekstkleur",
+      description: "Standaard kleur voor tekst.",
+    },
+    {
+      key: "muted",
+      label: "Secundaire tekst",
+      description: "Kleur voor subtiele teksten en toelichtingen.",
+    },
+    {
+      key: "border",
+      label: "Randen",
+      description: "Kleur voor randen en scheidingslijnen.",
+    },
+    {
+      key: "accent",
+      label: "Accent",
+      description: "Wordt gebruikt voor actieve navigatie en accenten.",
+    },
+    {
+      key: "accentText",
+      label: "Accent-tekst",
+      description: "Tekstkleur op het accent, bijvoorbeeld bij actieve navigatie.",
+    },
+  ];
+
+  const handleColorChange = (key: keyof ThemeSettings, value: string) => {
+    if (/^#[0-9a-fA-F]{6}$/.test(value)) {
+      setThemeColor(key, value.toLowerCase());
+    }
+  };
+
+  const fileInputRef = React.useRef<HTMLInputElement | null>(null);
+
+  const handleBackgroundUpload: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      event.target.value = "";
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result === "string") {
+        setBackgroundImage(result);
+      }
+    };
+    reader.readAsDataURL(file);
+    event.target.value = "";
+  };
+
+  const resetAllAppearance = () => {
+    resetTheme();
+    resetBackgroundImage();
+  };
+
   return (
     <div className="space-y-4">
-      <div className="text-lg font-semibold">Instellingen</div>
+      <div className="text-lg font-semibold theme-text">Instellingen</div>
 
-      <div className="rounded-2xl border bg-white p-4">
-        <div className="mb-2 font-medium">Mijn vakken</div>
+      <div className="rounded-2xl border theme-border theme-surface p-4">
+        <div className="mb-2 font-medium theme-text">Mijn vakken</div>
 
-        <div className="mb-3 text-sm text-gray-600">
+        <div className="mb-3 text-sm theme-muted">
           Kies welke vakken zichtbaar zijn in <strong>Weekoverzicht</strong>, <strong>Matrix</strong> en <strong>Deadlines</strong>.
         </div>
 
         <div className="mb-3 flex gap-2">
-          <button onClick={selectAll} className="rounded-md border px-2 py-1 text-sm">Alles selecteren</button>
-          <button onClick={clearAll} className="rounded-md border px-2 py-1 text-sm">Alles leegmaken</button>
+          <button
+            onClick={selectAll}
+            className="rounded-md border theme-border theme-surface px-2 py-1 text-sm"
+          >
+            Alles selecteren
+          </button>
+          <button
+            onClick={clearAll}
+            className="rounded-md border theme-border theme-surface px-2 py-1 text-sm"
+          >
+            Alles leegmaken
+          </button>
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 text-sm">
           {allVakken.map((vak) => (
-            <label key={vak} className="flex items-center gap-2 rounded-md border p-2 bg-white">
+            <label
+              key={vak}
+              className="flex items-center gap-2 rounded-md border theme-border theme-soft p-2"
+            >
               <input
                 type="checkbox"
                 checked={mijnVakken.includes(vak)}
@@ -50,20 +142,20 @@ export default function Settings() {
           ))}
         </div>
 
-        <div className="mt-4 text-xs text-gray-500">
+        <div className="mt-4 text-xs theme-muted">
           Deze lijst volgt automatisch de geüploade documenten.
         </div>
       </div>
 
-      <div className="rounded-2xl border bg-white p-4">
-        <div className="mb-2 font-medium">Huiswerkweergave</div>
+      <div className="rounded-2xl border theme-border theme-surface p-4">
+        <div className="mb-2 font-medium theme-text">Huiswerkweergave</div>
 
-        <div className="mb-3 text-sm text-gray-600">
+        <div className="mb-3 text-sm theme-muted">
           Kies hoe huiswerk wordt getoond in <strong>Weekoverzicht</strong> en <strong>Matrix</strong>.
         </div>
 
         <div className="space-y-2 text-sm">
-          <label className="flex items-center gap-2 rounded-md border p-2 bg-white">
+          <label className="flex items-center gap-2 rounded-md border theme-border theme-soft p-2">
             <input
               type="radio"
               name="huiswerkweergave"
@@ -73,7 +165,7 @@ export default function Settings() {
             />
             <span>Per opdracht (meerdere regels met vinkjes)</span>
           </label>
-          <label className="flex items-center gap-2 rounded-md border p-2 bg-white">
+          <label className="flex items-center gap-2 rounded-md border theme-border theme-soft p-2">
             <input
               type="radio"
               name="huiswerkweergave"
@@ -83,6 +175,76 @@ export default function Settings() {
             />
             <span>Alles als één regel met één vinkje</span>
           </label>
+        </div>
+      </div>
+
+      <div className="rounded-2xl border theme-border theme-surface p-4 space-y-4">
+        <div className="font-medium theme-text">Thema &amp; achtergrond</div>
+
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          {colorOptions.map((option) => (
+            <div
+              key={option.key}
+              className="flex items-center justify-between gap-4 rounded-xl border theme-border theme-soft px-3 py-2"
+            >
+              <div className="flex-1">
+                <div className="text-sm font-medium theme-text">{option.label}</div>
+                <div className="text-xs theme-muted">{option.description}</div>
+              </div>
+              <div className="flex items-center gap-3">
+                <input
+                  type="color"
+                  aria-label={option.label}
+                  value={theme[option.key]}
+                  onChange={(event) => handleColorChange(option.key, event.target.value)}
+                  className="h-10 w-10 cursor-pointer rounded-md border theme-border bg-transparent p-0"
+                />
+                <span className="font-mono text-sm theme-text">{theme[option.key].toUpperCase()}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="space-y-3">
+          <div className="text-sm font-medium theme-text">Achtergrondafbeelding</div>
+          <div className="text-xs theme-muted">
+            Upload een afbeelding om als achtergrond te gebruiken. Grote afbeeldingen worden automatisch geschaald.
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              onChange={handleBackgroundUpload}
+              className="hidden"
+            />
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              className="rounded-md border theme-border theme-surface px-3 py-1 text-sm"
+            >
+              Kies afbeelding
+            </button>
+            <button
+              onClick={resetBackgroundImage}
+              className="rounded-md border theme-border theme-surface px-3 py-1 text-sm"
+              disabled={!backgroundImage}
+            >
+              Achtergrond resetten
+            </button>
+            <button
+              onClick={resetAllAppearance}
+              className="rounded-md border theme-border theme-surface px-3 py-1 text-sm"
+            >
+              Reset thema &amp; achtergrond
+            </button>
+          </div>
+          {backgroundImage ? (
+            <div className="h-32 w-full overflow-hidden rounded-xl border theme-border theme-soft">
+              <img src={backgroundImage} alt="Voorbeeld achtergrond" className="h-full w-full object-cover" />
+            </div>
+          ) : (
+            <div className="text-sm theme-muted">Er is nog geen achtergrond ingesteld.</div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/pages/Uploads.tsx
+++ b/frontend/src/pages/Uploads.tsx
@@ -100,63 +100,63 @@ export default function Uploads() {
 
   return (
     <div className="space-y-4">
-      <div className="text-lg font-semibold">Uploads &amp; Documentbeheer</div>
+      <div className="text-lg font-semibold theme-text">Uploads &amp; Documentbeheer</div>
 
       {/* Uploadblok */}
-      <div className="rounded-2xl border bg-white p-4">
-        <div className="mb-1 font-medium">Bestanden uploaden</div>
-        <div className="text-sm text-gray-600 mb-2">
+      <div className="rounded-2xl border theme-border theme-surface p-4">
+        <div className="mb-1 font-medium theme-text">Bestanden uploaden</div>
+        <div className="text-sm theme-muted mb-2">
           Kies een <strong>PDF</strong> of <strong>DOCX</strong>. Metadata wordt automatisch herkend.
         </div>
         <input type="file" accept=".pdf,.docx" multiple onChange={handleUpload} />
-        {isUploading && <div className="mt-2 text-sm text-gray-500">Bezig met uploaden…</div>}
+        {isUploading && <div className="mt-2 text-sm theme-muted">Bezig met uploaden…</div>}
         {error && <div className="mt-2 text-sm text-red-600">{error}</div>}
       </div>
 
       {/* Metadata-overzicht */}
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <div className="rounded-2xl border bg-white p-3">
-          <div className="text-xs text-gray-500 mb-1">Beschikbare vakken</div>
+        <div className="rounded-2xl border theme-border theme-surface p-3">
+          <div className="text-xs theme-muted mb-1">Beschikbare vakken</div>
           <div className="flex flex-wrap gap-1">
             {meta.vakken.map((v) => (
-              <span key={v} className="text-xs rounded-full border bg-white px-2 py-0.5">
+              <span key={v} className="text-xs rounded-full border theme-border theme-surface px-2 py-0.5">
                 {v}
               </span>
             ))}
-            {meta.vakken.length === 0 && <span className="text-xs text-gray-400">—</span>}
+            {meta.vakken.length === 0 && <span className="text-xs theme-muted opacity-70">—</span>}
           </div>
         </div>
-        <div className="rounded-2xl border bg-white p-3">
-          <div className="text-xs text-gray-500 mb-1">Niveaus</div>
+        <div className="rounded-2xl border theme-border theme-surface p-3">
+          <div className="text-xs theme-muted mb-1">Niveaus</div>
           <div className="flex flex-wrap gap-1">
             {meta.niveaus.map((n) => (
-              <span key={n} className="text-xs rounded-full border bg-white px-2 py-0.5">
+              <span key={n} className="text-xs rounded-full border theme-border theme-surface px-2 py-0.5">
                 {n}
               </span>
             ))}
-            {meta.niveaus.length === 0 && <span className="text-xs text-gray-400">—</span>}
+            {meta.niveaus.length === 0 && <span className="text-xs theme-muted opacity-70">—</span>}
           </div>
         </div>
-        <div className="rounded-2xl border bg-white p-3">
-          <div className="text-xs text-gray-500 mb-1">Leerjaren</div>
+        <div className="rounded-2xl border theme-border theme-surface p-3">
+          <div className="text-xs theme-muted mb-1">Leerjaren</div>
           <div className="flex flex-wrap gap-1">
             {meta.leerjaren.map((j) => (
-              <span key={j} className="text-xs rounded-full border bg-white px-2 py-0.5">
+              <span key={j} className="text-xs rounded-full border theme-border theme-surface px-2 py-0.5">
                 {j}
               </span>
             ))}
-            {meta.leerjaren.length === 0 && <span className="text-xs text-gray-400">—</span>}
+            {meta.leerjaren.length === 0 && <span className="text-xs theme-muted opacity-70">—</span>}
           </div>
         </div>
-        <div className="rounded-2xl border bg-white p-3">
-          <div className="text-xs text-gray-500 mb-1">Periodes &amp; Weken</div>
+        <div className="rounded-2xl border theme-border theme-surface p-3">
+          <div className="text-xs theme-muted mb-1">Periodes &amp; Weken</div>
           <div className="flex flex-wrap items-center gap-1">
             {meta.periodes.map((p) => (
-              <span key={p} className="text-xs rounded-full border bg-white px-2 py-0.5">
+              <span key={p} className="text-xs rounded-full border theme-border theme-surface px-2 py-0.5">
                 P{p}
               </span>
             ))}
-            <span className="text-xs text-gray-500 ml-2">wk {meta.weekBereik}</span>
+            <span className="text-xs theme-muted ml-2">wk {meta.weekBereik}</span>
           </div>
         </div>
       </div>
@@ -167,10 +167,10 @@ export default function Uploads() {
           placeholder="Zoek vak…"
           value={filters.vak}
           onChange={(e) => setFilters((f) => ({ ...f, vak: e.target.value }))}
-          className="rounded-md border px-2 py-1"
+          className="rounded-md border theme-border theme-surface px-2 py-1"
         />
         <select
-          className="rounded-md border px-2 py-1"
+          className="rounded-md border theme-border theme-surface px-2 py-1"
           value={filters.niveau}
           onChange={(e) => setFilters((f) => ({ ...f, niveau: e.target.value }))}
         >
@@ -182,7 +182,7 @@ export default function Uploads() {
           ))}
         </select>
         <select
-          className="rounded-md border px-2 py-1"
+          className="rounded-md border theme-border theme-surface px-2 py-1"
           value={filters.leerjaar}
           onChange={(e) => setFilters((f) => ({ ...f, leerjaar: e.target.value }))}
         >
@@ -194,7 +194,7 @@ export default function Uploads() {
           ))}
         </select>
         <select
-          className="rounded-md border px-2 py-1"
+          className="rounded-md border theme-border theme-surface px-2 py-1"
           value={filters.periode}
           onChange={(e) => setFilters((f) => ({ ...f, periode: e.target.value }))}
         >
@@ -208,7 +208,7 @@ export default function Uploads() {
         {(filters.vak || filters.niveau || filters.leerjaar || filters.periode) && (
           <button
             onClick={reset}
-            className="ml-2 inline-flex items-center gap-1 rounded-md border px-2 py-1"
+            className="ml-2 inline-flex items-center gap-1 rounded-md border theme-border theme-surface px-2 py-1"
             title="Reset filters"
           >
             <XCircle size={14} /> Reset
@@ -217,8 +217,8 @@ export default function Uploads() {
       </div>
 
       {/* Tabel */}
-      <div className="rounded-2xl border bg-white">
-        <div className="grid grid-cols-[90px_minmax(0,2fr)_repeat(6,minmax(0,1fr))_repeat(2,minmax(0,1.2fr))] gap-2 text-xs font-medium text-gray-600 border-b pb-2 px-4 pt-3">
+      <div className="rounded-2xl border theme-border theme-surface">
+        <div className="grid grid-cols-[90px_minmax(0,2fr)_repeat(6,minmax(0,1fr))_repeat(2,minmax(0,1.2fr))] gap-2 text-xs font-medium theme-muted border-b theme-border pb-2 px-4 pt-3">
           <div className="flex justify-center">Gebruik</div>
           <div>Bestand</div>
           <div>Vak</div>
@@ -231,13 +231,13 @@ export default function Uploads() {
         </div>
 
         {filtered.length === 0 ? (
-          <div className="p-6 text-sm text-gray-600">Geen documenten gevonden.</div>
+          <div className="p-6 text-sm theme-muted">Geen documenten gevonden.</div>
         ) : (
           filtered.map((d, i) => (
             <div
               key={d.fileId}
               className={`grid grid-cols-[90px_minmax(0,2fr)_repeat(6,minmax(0,1fr))_repeat(2,minmax(0,1.2fr))] gap-2 text-sm items-center px-4 py-3 ${
-                i > 0 ? "border-t" : ""
+                i > 0 ? "border-t theme-border" : ""
               }`}
             >
               <div className="flex justify-center">
@@ -270,18 +270,22 @@ export default function Uploads() {
               <div className="flex gap-2 col-span-2">
                 <button
                   title={`Bron: ${d.bestand}`}
-                  className="rounded-lg border bg-white p-1"
+                  className="rounded-lg border theme-border theme-surface p-1"
                   onClick={() => openPreview({ fileId: d.fileId, filename: d.bestand })}
                 >
                   <FileText size={16} />
                 </button>
-                <button onClick={() => setDetailDoc(d)} title="Meta-details" className="rounded-lg border bg-white p-1">
+                <button
+                  onClick={() => setDetailDoc(d)}
+                  title="Meta-details"
+                  className="rounded-lg border theme-border theme-surface p-1"
+                >
                   <Info size={16} />
                 </button>
                 <button
                   onClick={() => handleDelete(d.fileId)}
                   title="Verwijder"
-                  className="rounded-lg border bg-white p-1 text-red-600"
+                  className="rounded-lg border theme-border theme-surface p-1 text-red-600"
                 >
                   <Trash2 size={16} />
                 </button>
@@ -294,10 +298,10 @@ export default function Uploads() {
       {/* Detail modal */}
       {detailDoc && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-          <div className="bg-white rounded-2xl shadow-lg w-full max-w-md p-6">
+          <div className="rounded-2xl border theme-border theme-surface shadow-lg w-full max-w-md p-6">
             <div className="flex items-center justify-between mb-4">
               <h2 className="text-lg font-semibold">Metadata — {detailDoc.bestand}</h2>
-              <button onClick={() => setDetailDoc(null)} className="text-gray-500" aria-label="Sluiten">
+              <button onClick={() => setDetailDoc(null)} className="theme-muted" aria-label="Sluiten">
                 ✕
               </button>
             </div>

--- a/frontend/src/pages/WeekOverview.tsx
+++ b/frontend/src/pages/WeekOverview.tsx
@@ -82,7 +82,7 @@ function Card({
       : filteredHomeworkItems.join("\n");
 
   return (
-    <div className="rounded-2xl border bg-white shadow-sm p-4 flex flex-col gap-3">
+    <div className="rounded-2xl border theme-border theme-surface shadow-sm p-4 flex flex-col gap-3">
       <div className="flex items-center justify-between">
         <div className="font-semibold">{vak}</div>
         <div className="flex gap-2">
@@ -95,7 +95,7 @@ function Card({
               title="Toon details (lesstof/opmerkingen)"
               aria-label={`Details ${vak}`}
             >
-              <Info size={16} className="text-gray-600" />
+              <Info size={16} className="theme-muted" />
             </button>
           )}
           <button
@@ -105,7 +105,7 @@ function Card({
             disabled={!onOpenDoc}
             className="disabled:opacity-40"
           >
-            <FileText size={16} className="text-gray-600" />
+            <FileText size={16} className="theme-muted" />
           </button>
         </div>
       </div>
@@ -125,7 +125,7 @@ function Card({
                       onChange={() => toggleItem(idx)}
                       className="mt-0.5"
                     />
-                    <span className={`flex-1 ${checked ? "line-through text-gray-400" : ""}`}>
+                    <span className={`flex-1 ${checked ? "line-through theme-muted opacity-80" : ""}`}>
                       {item}
                     </span>
                   </label>
@@ -134,7 +134,7 @@ function Card({
             })}
           </ul>
         ) : (
-          <div className="text-sm text-gray-500">Geen huiswerk</div>
+          <div className="text-sm theme-muted">Geen huiswerk</div>
         )
       ) : aggregatedHomework ? (
         <label className="flex items-start gap-2 text-sm">
@@ -146,27 +146,29 @@ function Card({
             className="mt-0.5"
           />
           <span
-            className={`flex-1 whitespace-pre-line ${allDone ? "line-through text-gray-400" : ""}`}
+            className={`flex-1 whitespace-pre-line ${allDone ? "line-through theme-muted opacity-80" : ""}`}
           >
             {aggregatedHomework}
           </span>
         </label>
       ) : (
-        <div className="text-sm text-gray-500">Geen huiswerk</div>
+        <div className="text-sm theme-muted">Geen huiswerk</div>
       )}
 
-      <div className={`text-sm text-gray-700 ${allDone ? "opacity-70" : ""}`} title={data?.date || ""}>
+      <div className={`text-sm theme-muted ${allDone ? "opacity-80" : ""}`} title={data?.date || ""}>
         {data?.deadlines || "Geen toets/deadline"}
       </div>
 
       {open && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-          <div className="bg-white rounded-2xl shadow-lg w-full max-w-md p-6">
+          <div className="rounded-2xl border theme-border theme-surface shadow-lg w-full max-w-md p-6">
             <div className="flex items-center justify-between mb-4">
               <h2 className="text-lg font-semibold">
                 {vak} – Week {weekNr}
               </h2>
-              <button onClick={() => setOpen(false)} className="text-gray-500" aria-label="Sluiten">✕</button>
+              <button onClick={() => setOpen(false)} className="theme-muted" aria-label="Sluiten">
+                ✕
+              </button>
             </div>
             <div className="text-sm whitespace-pre-wrap">
               Lesstof: {data?.lesstof || "—"}
@@ -310,8 +312,8 @@ export default function WeekOverview() {
   return (
     <div>
       <div className="mb-4">
-        <h1 className="text-lg font-semibold">Weekoverzicht</h1>
-        <div className="mt-1 text-sm text-gray-600">
+        <h1 className="text-lg font-semibold theme-text">Weekoverzicht</h1>
+        <div className="mt-1 text-sm theme-muted">
           Week {week?.nr ?? "—"} · {week ? formatRange(week) : "Geen data"}
         </div>
       </div>
@@ -319,7 +321,7 @@ export default function WeekOverview() {
       <div className="mb-4 flex flex-wrap gap-2 items-center">
         <button
           onClick={goThisWeek}
-          className="rounded-md border px-2 py-1 text-sm disabled:opacity-40 disabled:cursor-not-allowed"
+          className="rounded-md border theme-border theme-surface px-2 py-1 text-sm disabled:opacity-40 disabled:cursor-not-allowed"
           title="Spring naar deze week"
           aria-label="Deze week"
           disabled={disableWeekControls}
@@ -328,16 +330,16 @@ export default function WeekOverview() {
         </button>
         <button
           onClick={() => setWeekIdxWO(Math.max(0, weekIdxWO - 1))}
-          className="rounded-md border px-2 py-1 text-sm disabled:opacity-40 disabled:cursor-not-allowed"
+          className="rounded-md border theme-border theme-surface px-2 py-1 text-sm disabled:opacity-40 disabled:cursor-not-allowed"
           title="Vorige week"
           disabled={disableWeekControls}
         >
           ◀
         </button>
-        <span className="text-sm text-gray-800">Week {week?.nr ?? "—"}</span>
+        <span className="text-sm theme-text">Week {week?.nr ?? "—"}</span>
         <button
           onClick={() => setWeekIdxWO(Math.min(Math.max(weeks.length - 1, 0), weekIdxWO + 1))}
-          className="rounded-md border px-2 py-1 text-sm disabled:opacity-40 disabled:cursor-not-allowed"
+          className="rounded-md border theme-border theme-surface px-2 py-1 text-sm disabled:opacity-40 disabled:cursor-not-allowed"
           title="Volgende week"
           disabled={disableWeekControls}
         >
@@ -345,7 +347,7 @@ export default function WeekOverview() {
         </button>
 
         <select
-          className="rounded-md border px-2 py-1 text-sm"
+          className="rounded-md border theme-border theme-surface px-2 py-1 text-sm"
           value={niveauWO}
           onChange={(e) => setNiveauWO(e.target.value as any)}
           aria-label="Filter niveau"
@@ -361,7 +363,7 @@ export default function WeekOverview() {
         </select>
 
         <select
-          className="rounded-md border px-2 py-1 text-sm"
+          className="rounded-md border theme-border theme-surface px-2 py-1 text-sm"
           value={leerjaarWO}
           onChange={(e) => setLeerjaarWO(e.target.value)}
           aria-label="Filter leerjaar"
@@ -378,15 +380,15 @@ export default function WeekOverview() {
       </div>
 
       {!hasActiveDocs ? (
-        <div className="rounded-2xl border bg-white p-6 text-sm text-gray-600">
+        <div className="rounded-2xl border theme-border theme-surface p-6 text-sm theme-muted">
           Nog geen uploads. Voeg eerst één of meer studiewijzers toe via <strong>Uploads</strong>.
         </div>
       ) : !hasWeekData ? (
-        <div className="rounded-2xl border bg-white p-6 text-sm text-gray-600">
+        <div className="rounded-2xl border theme-border theme-surface p-6 text-sm theme-muted">
           Nog geen weekgegevens beschikbaar. Controleer of de documenten studiewijzerdata bevatten.
         </div>
       ) : !hasDocsForFilters ? (
-        <div className="rounded-2xl border bg-white p-6 text-sm text-gray-600">
+        <div className="rounded-2xl border theme-border theme-surface p-6 text-sm theme-muted">
           Geen vakken voor deze filters. Pas de selectie aan of controleer de metadata van de documenten.
         </div>
       ) : (


### PR DESCRIPTION
## Summary
- add theme settings and background image state to the global store
- introduce theme utility classes and apply them across the layout and content pages
- extend the settings screen with color pickers, background upload/reset actions, and updated styling controls

## Testing
- npm run build *(fails: rollup optional dependency missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e1388f388322a38a6d3ac90eb8a3