### PR TITLE
Persist application state and add reset option

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useAppStore, type ThemeSettings } from "../app/store";
+import { useAppStore, type ThemeSettings, hydrateDocsFromApi } from "../app/store";
 
 export default function Settings() {
   const {
@@ -13,6 +13,7 @@ export default function Settings() {
     backgroundImage,
     setBackgroundImage,
     resetBackgroundImage,
+    resetAppState,
   } = useAppStore();
   const docs = useAppStore((s) => s.docs) ?? [];
 
@@ -98,6 +99,18 @@ export default function Settings() {
   const resetAllAppearance = () => {
     resetTheme();
     resetBackgroundImage();
+  };
+
+  const handleResetApplication = () => {
+    const confirmed = window.confirm(
+      "Weet je zeker dat je alle gegevens wilt wissen en terug wilt naar de beginstatus? " +
+        "Instellingen, selecties en afgevinkte items gaan verloren."
+    );
+    if (!confirmed) {
+      return;
+    }
+    resetAppState();
+    void hydrateDocsFromApi();
   };
 
   return (
@@ -246,6 +259,20 @@ export default function Settings() {
             <div className="text-sm theme-muted">Er is nog geen achtergrond ingesteld.</div>
           )}
         </div>
+      </div>
+
+      <div className="rounded-2xl border theme-border theme-surface p-4 space-y-3">
+        <div className="font-medium theme-text">Applicatie resetten</div>
+        <div className="text-sm theme-muted">
+          Wis alle opgeslagen gegevens en laad de planner opnieuw alsof je de applicatie voor het eerst opent.
+          Documenten worden opnieuw opgehaald vanaf de server en persoonlijke instellingen gaan verloren.
+        </div>
+        <button
+          onClick={handleResetApplication}
+          className="w-full rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm font-medium text-red-700 transition-colors hover:bg-red-100"
+        >
+          Alles wissen en terug naar beginstatus
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- persist the global Zustand store to localStorage so user preferences, doc toggles and UI state survive reloads
- add an app-level reset action that restores the initial state for all modules
- expose the reset through Settings with a confirmation dialog and refresh the planner data afterwards

## Testing
- npm run build *(fails: optional dependency @rollup/rollup-linux-x64-gnu missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9eae218a88322bcd5c60e03e4fb56