### PR TITLE
Improve matrix layout, persist filters, and expose version

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,6 @@ npm run dev
 3. Upload één of meerdere studiewijzers via _Uploads_.
 4. Beheer huiswerk in Weekoverzicht of Matrix overzicht en bekijk events via _Belangrijke events_.
 
-## Overige info
-- De repo bevat een `.devcontainer` voor GitHub Codespaces (Python 3.11 + Node 20).
-- Exporteren naar CSV/iCal is nog niet geïmplementeerd.
 
 ## Licentie
 MIT

--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -111,6 +111,15 @@ type State = {
   setNiveauWO: (n: "HAVO" | "VWO" | "ALLE") => void;
   leerjaarWO: string;
   setLeerjaarWO: (j: string) => void;
+  // ==== matrix (UI state) ====
+  matrixStartIdx: number;
+  setMatrixStartIdx: (n: number) => void;
+  matrixCount: number;
+  setMatrixCount: (n: number) => void;
+  matrixNiveau: "HAVO" | "VWO" | "ALLE";
+  setMatrixNiveau: (n: "HAVO" | "VWO" | "ALLE") => void;
+  matrixLeerjaar: string;
+  setMatrixLeerjaar: (j: string) => void;
   resetAppState: () => void;
 };
 
@@ -345,6 +354,10 @@ const createInitialState = (): Pick<
   | "weekIdxWO"
   | "niveauWO"
   | "leerjaarWO"
+  | "matrixStartIdx"
+  | "matrixCount"
+  | "matrixNiveau"
+  | "matrixLeerjaar"
 > => ({
   docs: [],
   docRows: {},
@@ -359,6 +372,10 @@ const createInitialState = (): Pick<
   weekIdxWO: 0,
   niveauWO: "ALLE",
   leerjaarWO: "ALLE",
+  matrixStartIdx: -1,
+  matrixCount: 3,
+  matrixNiveau: "ALLE",
+  matrixLeerjaar: "ALLE",
 });
 
 export const useAppStore = create<State>()(
@@ -654,6 +671,23 @@ export const useAppStore = create<State>()(
       setWeekIdxWO: (n) => set({ weekIdxWO: n }),
       setNiveauWO: (n) => set({ niveauWO: n }),
       setLeerjaarWO: (j) => set({ leerjaarWO: j }),
+      setMatrixStartIdx: (value) =>
+        set(() => {
+          const numeric = Number.isFinite(value) ? Math.floor(value) : -1;
+          return { matrixStartIdx: Math.max(-1, numeric) };
+        }),
+      setMatrixCount: (value) =>
+        set(() => {
+          const numeric = Number.isFinite(value) ? Math.floor(value) : 3;
+          const clamped = Math.min(6, Math.max(1, numeric));
+          return { matrixCount: clamped };
+        }),
+      setMatrixNiveau: (n) =>
+        set({ matrixNiveau: n === "HAVO" || n === "VWO" || n === "ALLE" ? n : "ALLE" }),
+      setMatrixLeerjaar: (j) => {
+        const next = j && j.trim() ? j : "ALLE";
+        set({ matrixLeerjaar: next });
+      },
 
       resetAppState: () => {
         const initial = createInitialState();
@@ -677,6 +711,10 @@ export const useAppStore = create<State>()(
         weekIdxWO: state.weekIdxWO,
         niveauWO: state.niveauWO,
         leerjaarWO: state.leerjaarWO,
+        matrixStartIdx: state.matrixStartIdx,
+        matrixCount: state.matrixCount,
+        matrixNiveau: state.matrixNiveau,
+        matrixLeerjaar: state.matrixLeerjaar,
       }),
     }
   )

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 import { NavLink } from "react-router-dom";
+import packageJson from "../../../package.json";
 import { useAppStore } from "../../app/store";
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
   const theme = useAppStore((state) => state.theme);
   const backgroundImage = useAppStore((state) => state.backgroundImage);
+  const appVersion = packageJson.version ?? "0.0.0";
 
   const themeStyle = React.useMemo(() => {
     const base = {
@@ -98,7 +100,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
         </div>
       </main>
       <footer className="mx-auto max-w-6xl px-4 py-5 text-xs theme-muted">
-        © {new Date().getFullYear()} Het Vlier Studiewijzer Planner - made by Ramon Ankersmit
+        © {new Date().getFullYear()} Het Vlier Studiewijzer Planner · versie {appVersion} · made by Ramon Ankersmit
       </footer>
     </div>
   );


### PR DESCRIPTION
## Summary
- retain the README heading while removing the redundant "Overige info" section
- adjust the matrix cell layout, hide placeholder dashes for deadlines, and persist matrix filters in the global store
- surface the package version in the application footer

## Testing
- npm run build *(fails: missing optional dependency @rollup/rollup-linux-x64-gnu in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cac9990be48322a0817cf0be9ae68c