### PR TITLE
Allow adjusting surface opacity and align homework button

### DIFF
--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -98,6 +98,9 @@ type State = {
   backgroundImage: string | null;
   setBackgroundImage: (value: string | null) => void;
   resetBackgroundImage: () => void;
+  surfaceOpacity: number;
+  setSurfaceOpacity: (value: number) => void;
+  resetSurfaceOpacity: () => void;
 
   // ==== afvinkstatus gedeeld ====
   doneMap: Record<string, boolean>;
@@ -350,6 +353,7 @@ const createInitialState = (): Pick<
   | "huiswerkWeergave"
   | "theme"
   | "backgroundImage"
+  | "surfaceOpacity"
   | "doneMap"
   | "weekIdxWO"
   | "niveauWO"
@@ -368,6 +372,7 @@ const createInitialState = (): Pick<
   huiswerkWeergave: "perOpdracht",
   theme: { ...defaultTheme },
   backgroundImage: null,
+  surfaceOpacity: 100,
   doneMap: {},
   weekIdxWO: 0,
   niveauWO: "ALLE",
@@ -640,6 +645,13 @@ export const useAppStore = create<State>()(
       resetTheme: () => set({ theme: { ...defaultTheme } }),
       setBackgroundImage: (value) => set({ backgroundImage: value }),
       resetBackgroundImage: () => set({ backgroundImage: null }),
+      setSurfaceOpacity: (value) =>
+        set(() => {
+          const numeric = Number.isFinite(value) ? Math.round(value) : 100;
+          const clamped = Math.min(100, Math.max(0, numeric));
+          return { surfaceOpacity: clamped };
+        }),
+      resetSurfaceOpacity: () => set({ surfaceOpacity: 100 }),
 
       // ----------------------------
       // done-map
@@ -707,6 +719,7 @@ export const useAppStore = create<State>()(
         huiswerkWeergave: state.huiswerkWeergave,
         theme: state.theme,
         backgroundImage: state.backgroundImage,
+        surfaceOpacity: state.surfaceOpacity,
         doneMap: state.doneMap,
         weekIdxWO: state.weekIdxWO,
         niveauWO: state.niveauWO,

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,17 +1,37 @@
 import React from "react";
 import { NavLink } from "react-router-dom";
+import { Coffee } from "lucide-react";
 import packageJson from "../../../package.json";
 import { useAppStore } from "../../app/store";
+
+const clamp01 = (value: number) => Math.min(1, Math.max(0, value));
+
+const hexToRgba = (color: string, alpha: number) => {
+  const match = color.match(/^#?([0-9a-f]{6})$/i);
+  if (!match) {
+    return color;
+  }
+  const hex = match[1];
+  const r = parseInt(hex.slice(0, 2), 16);
+  const g = parseInt(hex.slice(2, 4), 16);
+  const b = parseInt(hex.slice(4, 6), 16);
+  const normalized = clamp01(alpha);
+  const roundedAlpha = Math.round(normalized * 100) / 100;
+  return `rgba(${r}, ${g}, ${b}, ${roundedAlpha})`;
+};
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
   const theme = useAppStore((state) => state.theme);
   const backgroundImage = useAppStore((state) => state.backgroundImage);
+  const surfaceOpacity = useAppStore((state) => state.surfaceOpacity);
   const appVersion = packageJson.version ?? "0.0.0";
 
   const themeStyle = React.useMemo(() => {
+    const surfaceAlpha = clamp01(surfaceOpacity / 100);
+    const resolvedSurface = hexToRgba(theme.surface, surfaceAlpha);
     const base = {
       "--app-background": theme.background,
-      "--app-surface": theme.surface,
+      "--app-surface": resolvedSurface,
       "--app-accent": theme.accent,
       "--app-text": theme.text,
       "--app-muted": theme.muted,
@@ -32,14 +52,13 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
       base.backgroundAttachment = "scroll";
     }
     return base;
-  }, [theme, backgroundImage]);
+  }, [theme, backgroundImage, surfaceOpacity]);
 
   const headerBackground = React.useMemo(() => {
-    if (theme.surface.startsWith("#") && theme.surface.length === 7) {
-      return `${theme.surface}cc`;
-    }
-    return theme.surface;
-  }, [theme.surface]);
+    const surfaceAlpha = clamp01(surfaceOpacity / 100);
+    const headerAlpha = clamp01(surfaceAlpha * 0.6 + 0.2);
+    return hexToRgba(theme.surface, headerAlpha);
+  }, [theme.surface, surfaceOpacity]);
 
   const linkBase = "rounded-md border px-3 py-1 text-sm transition-colors theme-border";
   return (
@@ -99,8 +118,24 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
           {children}
         </div>
       </main>
-      <footer className="mx-auto max-w-6xl px-4 py-5 text-xs theme-muted">
-        © {new Date().getFullYear()} Het Vlier Studiewijzer Planner · versie {appVersion} · made by Ramon Ankersmit
+      <footer className="mx-auto max-w-6xl px-4 py-5 text-xs text-[var(--app-muted)]">
+        <div className="flex flex-wrap items-center gap-2">
+          <span>© {new Date().getFullYear()} Het Vlier Studiewijzer Planner</span>
+          <span>·</span>
+          <span>versie {appVersion}</span>
+          <span>·</span>
+          <span>made by Ramon Ankersmit</span>
+          <span>·</span>
+          <a
+            href="https://buymeacoffee.com/ramonankersmit"
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center gap-1 rounded-full border border-transparent px-2 py-1 transition-colors hover:border-[var(--app-border)] hover:text-[var(--app-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-border)]"
+          >
+            <Coffee size={14} aria-hidden="true" />
+            <span>Trakteer op koffie</span>
+          </a>
+        </div>
       </footer>
     </div>
   );

--- a/frontend/src/pages/Matrix.tsx
+++ b/frontend/src/pages/Matrix.tsx
@@ -264,7 +264,7 @@ function MatrixCell({
 
   return (
     <td className="px-4 py-2 align-top">
-      <div className="flex flex-col gap-2 min-w-[14rem]">
+      <div className="flex h-full min-w-[14rem] flex-col gap-2">
         <div className="flex flex-wrap items-center gap-2 text-xs theme-muted">
           {hasOpmerkingen && (
             <span
@@ -510,7 +510,7 @@ function MatrixCell({
         {!adding && !editing && (
           <button
             type="button"
-            className="flex items-center gap-1 text-xs text-slate-500 hover:text-slate-900"
+            className="mt-auto flex items-center gap-1 text-xs text-slate-500 hover:text-slate-900"
             onClick={startAdd}
             title="Eigen huiswerk toevoegen"
             aria-label={`Voeg huiswerk toe voor ${vak}`}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -14,6 +14,9 @@ export default function Settings() {
     backgroundImage,
     setBackgroundImage,
     resetBackgroundImage,
+    surfaceOpacity,
+    setSurfaceOpacity,
+    resetSurfaceOpacity,
     resetAppState,
   } = useAppStore();
   const docs = useAppStore((s) => s.docs) ?? [];
@@ -100,6 +103,7 @@ export default function Settings() {
   const resetAllAppearance = () => {
     resetTheme();
     resetBackgroundImage();
+    resetSurfaceOpacity();
   };
 
   const handleResetApplication = async () => {
@@ -268,6 +272,26 @@ export default function Settings() {
           ) : (
             <div className="text-sm theme-muted">Er is nog geen achtergrond ingesteld.</div>
           )}
+          <div className="space-y-1">
+            <label className="text-sm font-medium theme-text" htmlFor="surface-opacity">
+              Doorzichtigheid kaarten
+            </label>
+            <div className="flex items-center gap-3">
+              <input
+                id="surface-opacity"
+                type="range"
+                min={0}
+                max={100}
+                value={surfaceOpacity}
+                onChange={(event) => setSurfaceOpacity(Number(event.target.value))}
+                className="h-2 w-full accent-slate-900"
+              />
+              <span className="w-12 text-right text-sm font-medium theme-text">{surfaceOpacity}%</span>
+            </div>
+            <div className="text-xs theme-muted">
+              Bepaalt hoe sterk kaarten en panelen het achtergrondbeeld afdekken.
+            </div>
+          </div>
         </div>
       </div>
 

--- a/frontend/src/pages/WeekOverview.tsx
+++ b/frontend/src/pages/WeekOverview.tsx
@@ -261,7 +261,7 @@ function Card({
   };
 
   return (
-    <div className="rounded-2xl border theme-border theme-surface shadow-sm p-4 flex flex-col gap-3">
+    <div className="rounded-2xl border theme-border theme-surface shadow-sm p-4 flex h-full flex-col gap-3">
       <div className="flex items-center justify-between">
         <div className="font-semibold">{vak}</div>
         <div className="flex items-center gap-2">
@@ -523,7 +523,7 @@ function Card({
       {!adding && !editing && (
         <button
           type="button"
-          className="flex items-center gap-1 text-sm text-slate-500 hover:text-slate-900"
+          className="mt-auto flex items-center gap-1 text-sm text-slate-500 hover:text-slate-900"
           onClick={startAdd}
           title="Eigen huiswerk toevoegen"
           aria-label={`Voeg huiswerk toe voor ${vak}`}


### PR DESCRIPTION
## Summary
- add a persisted surface-opacity setting and expose it in Settings with a slider
- render theme surfaces with configurable transparency, update the header, and add a coffee link to the footer
- align the “Eigen huiswerk toevoegen” actions to the bottom of matrix and week overview cards

## Testing
- npm run build *(fails: rollup optional dependency @rollup/rollup-linux-x64-gnu is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cad689d5f48322964ac21977efc1e6