### PR TITLE
Handle vakantie logic and add UI dividers

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -35,6 +35,13 @@ body {
   border-color: var(--app-border) !important;
 }
 
+.theme-divider {
+  width: 100%;
+  height: 1px;
+  background-color: var(--app-border);
+  opacity: 0.7;
+}
+
 .theme-text {
   color: var(--app-text) !important;
 }

--- a/frontend/src/pages/Deadlines.tsx
+++ b/frontend/src/pages/Deadlines.tsx
@@ -15,7 +15,7 @@ type Item = {
   week: number;
   isoYear: number;
   weekRange?: string;
-  type: "Toets" | "Deadline";
+  type: "Toets" | "Deadline" | "Vakantie";
   vak: string;
   title: string;
   date?: string;
@@ -105,8 +105,13 @@ export default function Deadlines() {
           if (mijnVakken.length && !mijnVakken.includes(vakNaam)) return [];
           if (vak !== "ALLE" && vakNaam !== vak) return [];
           if (!d?.deadlines || d.deadlines === "—") return [];
-          const type: Item["type"] =
-            String(d.deadlines).toLowerCase().includes("toets") ? "Toets" : "Deadline";
+          const deadlineLabel = String(d.deadlines);
+          const lowered = deadlineLabel.toLowerCase();
+          const type: Item["type"] = lowered.includes("vakantie")
+            ? "Vakantie"
+            : lowered.includes("toets")
+              ? "Toets"
+              : "Deadline";
           const doc = findDocForWeek(vakNaam, w);
           const weekRange = formatWeekDateRange(w) ?? undefined;
           return [

--- a/frontend/src/pages/Matrix.tsx
+++ b/frontend/src/pages/Matrix.tsx
@@ -306,6 +306,7 @@ function MatrixCell({
             <FileText size={14} />
           </button>
         </div>
+        <div className="theme-divider" aria-hidden="true" />
         <div className="flex flex-1 flex-col gap-2">
           <div className="text-sm">
             {mode === "perOpdracht" ? (

--- a/frontend/src/pages/WeekOverview.tsx
+++ b/frontend/src/pages/WeekOverview.tsx
@@ -318,6 +318,8 @@ function Card({
         </div>
       </div>
 
+      <div className="theme-divider" aria-hidden="true" />
+
       <div className="flex flex-1 flex-col gap-3">
         {mode === "perOpdracht" ? (
           hasAnyItems ? (


### PR DESCRIPTION
## Summary
- skip automatically imported huiswerk items mentioning "vakantie" when the row already labels vakantie in lesstof, toets or opmerkingen
- categorize belangrijke events containing "vakantie" as Vakantie and add a reusable theme divider style
- insert subtle dividers between card headers and homework content in the weekoverview and matrix views

## Testing
- npm run build *(fails: rollup optional dependency @rollup/rollup-linux-x64-gnu missing in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cae7ec03288322a9e4b1462e4886f6