### PR TITLE
Add backend package init for frozen imports

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,7 @@
+"""Backend package initialization."""
+
+# The backend package previously relied on implicit namespace packages, which
+# caused ``uvicorn`` to fail when importing ``backend.main`` from certain
+# distribution formats (e.g. frozen executables).  Providing an explicit
+# ``__init__`` module ensures the package can always be discovered.
+


### PR DESCRIPTION
## Summary
- add an explicit `backend.__init__` module so the backend package can be imported reliably when frozen into an executable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb0f722180832297bd52305f669c06