### PR TITLE
Provide fallback message when frontend build is missing

### DIFF
--- a/run_app.py
+++ b/run_app.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import uvicorn
 
+from backend import main as backend_main
+
 FALSE_VALUES = {"0", "false", "no", "off"}
 
 
@@ -33,7 +35,12 @@ def main() -> None:
     if should_enable(os.getenv("VLIER_OPEN_BROWSER")):
         open_browser(host, port)
 
-    uvicorn.run("backend.main:app", host=host, port=port, log_level=os.getenv("UVICORN_LOG_LEVEL", "info"))
+    uvicorn.run(
+        backend_main.app,
+        host=host,
+        port=port,
+        log_level=os.getenv("UVICORN_LOG_LEVEL", "info"),
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a fallback HTML response when the frontend build directory is absent but SERVE_FRONTEND is enabled
- reuse the same message for any non-API path instead of returning a 404 so users see how to build the frontend

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb118f84c483228f6369f1fa3463b5