### PR TITLE
Fix preview summary fallback prioritization

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -4,7 +4,7 @@ import logging
 from fastapi import FastAPI, UploadFile, File, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
-from typing import Any, List, Union
+from typing import Any, List, Optional, Union
 from pathlib import Path
 import mimetypes
 import shutil
@@ -48,16 +48,197 @@ STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
 class StoredDoc:
     meta: DocMeta
     rows: List[DocRow]
+    summary_html: Optional[str] = None
 
 
 # In-memory index (MVP). Later vervangen door DB.
 DOCS: dict[str, StoredDoc] = {}
 
 
+def _locate_source_file(file_id: str, meta: DocMeta) -> Optional[Path]:
+    """Vind het fysieke bronbestand voor een document (indien aanwezig)."""
+
+    suffix = Path(meta.bestand).suffix.lower()
+    if suffix:
+        candidate = STORAGE / f"{file_id}{suffix}"
+        if candidate.exists():
+            return candidate
+
+    for match in STORAGE.glob(f"{file_id}.*"):
+        if match.exists():
+            return match
+
+    return None
+
+
 def _row_to_dict(row: Union[DocRow, dict[str, Any]]) -> dict[str, Any]:
     if isinstance(row, DocRow):
         return row.dict()
     return dict(row)
+
+
+def _format_text(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    return escape(cleaned).replace("\n", "<br/>")
+
+
+def _format_string_list(values: Optional[List[str]]) -> Optional[str]:
+    if not values:
+        return None
+    items = [escape(item.strip()) for item in values if item and item.strip()]
+    if not items:
+        return None
+    return "<ul style=\"margin:0; padding-left:1.2rem;\">{}</ul>".format(
+        "".join(f"<li>{item}</li>" for item in items)
+    )
+
+
+def _format_toets(details: Optional[dict[str, Optional[str]]]) -> Optional[str]:
+    if not details:
+        return None
+    labels = {
+        "type": "Type",
+        "weging": "Weging",
+        "herkansing": "Herkansing",
+    }
+    items: list[str] = []
+    for key, label in labels.items():
+        value = details.get(key)
+        formatted = _format_text(value) if value is not None else None
+        if formatted:
+            items.append(
+                f"<li><strong>{escape(label)}:</strong> {formatted}</li>"
+            )
+    if not items:
+        return None
+    return "<ul style=\"margin:0; padding-left:1.2rem;\">{}</ul>".format(
+        "".join(items)
+    )
+
+
+def _format_resources(resources: Optional[List[dict[str, Optional[str]]]]) -> Optional[str]:
+    if not resources:
+        return None
+
+    items: list[str] = []
+    for resource in resources:
+        if not isinstance(resource, dict):
+            continue
+        title = resource.get("title") or resource.get("type") or resource.get("url")
+        title_html = escape(title.strip()) if isinstance(title, str) and title.strip() else None
+        url = resource.get("url")
+        if isinstance(url, str) and url.strip():
+            url_html = escape(url.strip())
+            if title_html:
+                items.append(
+                    "<li><a href=\"{url}\" target=\"_blank\" rel=\"noopener noreferrer\">{title}</a></li>".format(
+                        url=url_html, title=title_html
+                    )
+                )
+            else:
+                items.append(
+                    "<li><a href=\"{url}\" target=\"_blank\" rel=\"noopener noreferrer\">{url}</a></li>".format(
+                        url=url_html
+                    )
+                )
+            continue
+
+        if title_html:
+            items.append(f"<li>{title_html}</li>")
+
+    if not items:
+        return None
+
+    return "<ul style=\"margin:0; padding-left:1.2rem;\">{}</ul>".format(
+        "".join(items)
+    )
+
+
+def _build_summary_html(meta: DocMeta, rows: List[DocRow]) -> Optional[str]:
+    if not rows:
+        return None
+
+    header_parts = [escape(meta.vak)]
+    header_parts.append(f"Periode {meta.periode}")
+    header_parts.append(f"Niveau {escape(meta.niveau)}")
+    header_parts.append(f"Leerjaar {escape(meta.leerjaar)}")
+    if meta.schooljaar:
+        header_parts.append(escape(meta.schooljaar))
+
+    article: list[str] = []
+    article.append(
+        "<article style=\"font-family:system-ui,sans-serif;line-height:1.6;max-width:960px;margin:0 auto;\">"
+    )
+    article.append(
+        "<header style=\"border-bottom:1px solid #e2e8f0;padding-bottom:1rem;margin-bottom:1rem;\">"
+    )
+    article.append(
+        f"<h2 style=\"margin:0 0 .25rem;font-size:1.4rem;color:#0f172a;\">{escape(meta.bestand)}</h2>"
+    )
+    article.append(
+        "<p style=\"margin:0;color:#475569;font-size:.95rem;\">{}</p>".format(
+            " • ".join(header_parts)
+        )
+    )
+    article.append("</header>")
+
+    for row in rows:
+        data = row.dict()
+        week = data.get("week")
+        week_label = f"Week {week}" if week is not None else "Week —"
+        datum = data.get("datum")
+        subheading_bits: list[str] = [week_label]
+        if datum:
+            datum_html = _format_text(datum)
+            if datum_html:
+                subheading_bits.append(datum_html)
+        lead = data.get("onderwerp") or data.get("les")
+        if isinstance(lead, str) and lead.strip():
+            subheading_bits.append(escape(lead.strip()))
+
+        article.append(
+            "<section style=\"border-top:1px solid #e2e8f0;padding-top:1rem;margin-top:1rem;\">"
+        )
+        article.append(
+            "<h3 style=\"margin:0 0 .5rem;font-size:1.05rem;color:#0f172a;\">{}</h3>".format(
+                " • ".join(subheading_bits)
+            )
+        )
+        article.append("<dl style=\"margin:0\">")
+
+        fields = [
+            ("Onderwerp", _format_text(data.get("onderwerp"))),
+            ("Les", _format_text(data.get("les"))),
+            ("Leerdoelen", _format_string_list(data.get("leerdoelen"))),
+            ("Huiswerk", _format_text(data.get("huiswerk"))),
+            ("Opdracht", _format_text(data.get("opdracht"))),
+            ("Inleverdatum", _format_text(data.get("inleverdatum"))),
+            ("Toets", _format_toets(data.get("toets"))),
+            ("Bronnen", _format_resources(data.get("bronnen"))),
+            ("Notities", _format_text(data.get("notities"))),
+            ("Locatie", _format_text(data.get("locatie"))),
+            ("Klas / groep", _format_text(data.get("klas_of_groep"))),
+        ]
+
+        for label, value in fields:
+            if not value:
+                continue
+            article.append(
+                f"<dt style=\"font-weight:600;color:#0f172a;margin-top:.5rem;\">{escape(label)}</dt>"
+            )
+            article.append(
+                f"<dd style=\"margin:0 0 .5rem 0;color:#1f2937;\">{value}</dd>"
+            )
+
+        article.append("</dl>")
+        article.append("</section>")
+
+    article.append("</article>")
+    return "".join(article)
 
 
 def _save_state() -> None:
@@ -74,6 +255,8 @@ def _save_state() -> None:
             "meta": stored.meta.dict(),
             "rows": [_row_to_dict(row) for row in stored.rows],
         }
+        if stored.summary_html:
+            payload[file_id]["summaryHtml"] = stored.summary_html
 
     try:
         STATE_FILE.write_text(
@@ -111,14 +294,22 @@ def _load_state() -> None:
         except Exception as exc:
             logger.warning("Kon state entry %s niet herstellen: %s", file_id, exc)
             continue
-        suffix = Path(meta.bestand).suffix.lower()
-        file_path = STORAGE / f"{file_id}{suffix}"
-        if not file_path.exists():
-            fallback = next(STORAGE.glob(f"{file_id}.*"), None)
-            if not fallback or not fallback.exists():
-                logger.warning("Bestand voor %s ontbreekt; sla entry over", file_id)
+        summary_html = entry.get("summaryHtml")
+        file_path = _locate_source_file(file_id, meta)
+        if not file_path:
+            meta.hasSource = False
+            if not summary_html:
+                summary_html = _build_summary_html(meta, rows)
+            if not summary_html:
+                logger.warning(
+                    "Bestand voor %s ontbreekt en er is geen samenvatting; sla entry over",
+                    file_id,
+                )
                 continue
-        DOCS[file_id] = StoredDoc(meta=meta, rows=rows)
+        else:
+            meta.hasSource = True
+
+        DOCS[file_id] = StoredDoc(meta=meta, rows=rows, summary_html=summary_html)
 
 
 _load_state()
@@ -165,7 +356,12 @@ def _docx_to_html(path: Path) -> str:
 
 @app.get("/api/docs", response_model=List[DocMeta])
 def list_docs():
-    return [stored.meta for stored in DOCS.values()]
+    docs: List[DocMeta] = []
+    for file_id, stored in DOCS.items():
+        meta = stored.meta
+        meta.hasSource = _locate_source_file(file_id, meta) is not None
+        docs.append(meta)
+    return docs
 
 
 @app.get("/api/docs/{file_id}/rows", response_model=List[DocRow])
@@ -210,15 +406,13 @@ def get_doc_content(file_id: str, inline: bool = False):
         raise HTTPException(404, "Not found")
 
     meta = stored.meta
-    suffix = Path(meta.bestand).suffix.lower()
-    file_path = STORAGE / f"{file_id}{suffix}"
-    if not file_path.exists():
-        # fallback: zoek naar willekeurige match voor het geval de suffix verschilt
-        match = next(STORAGE.glob(f"{file_id}.*"), None)
-        if not match or not match.exists():
-            raise HTTPException(404, "File missing")
-        file_path = match
-        suffix = file_path.suffix.lower()
+    file_path = _locate_source_file(file_id, meta)
+    if not file_path:
+        meta.hasSource = False
+        raise HTTPException(404, "File missing")
+
+    meta.hasSource = True
+    suffix = file_path.suffix.lower()
 
     media_type, _ = mimetypes.guess_type(file_path.name)
     response = FileResponse(
@@ -245,29 +439,70 @@ def get_doc_preview(file_id: str):
         raise HTTPException(404, "Not found")
 
     meta = stored.meta
-    suffix = Path(meta.bestand).suffix.lower()
-    file_path = STORAGE / f"{file_id}{suffix}"
-    if not file_path.exists():
-        match = next(STORAGE.glob(f"{file_id}.*"), None)
-        if not match or not match.exists():
-            raise HTTPException(404, "File missing")
-        file_path = match
-        suffix = file_path.suffix.lower()
+    file_path = _locate_source_file(file_id, meta)
+    summary_html = stored.summary_html
+    updated_state = False
 
+    if not file_path:
+        meta.hasSource = False
+        if summary_html is None:
+            summary_html = _build_summary_html(meta, stored.rows)
+            if summary_html:
+                stored.summary_html = summary_html
+                updated_state = True
+        if summary_html:
+            if updated_state:
+                _save_state()
+            return {
+                "mediaType": "text/html",
+                "summaryHtml": summary_html,
+                "filename": meta.bestand,
+                "isEmbeddable": False,
+            }
+        raise HTTPException(404, "File missing")
+
+    meta.hasSource = True
+    suffix = file_path.suffix.lower()
     media_type, _ = mimetypes.guess_type(file_path.name)
+
     if suffix == ".docx":
-        html = _docx_to_html(file_path)
+        if summary_html is None:
+            try:
+                summary_html = _docx_to_html(file_path)
+            except HTTPException:
+                summary_html = _build_summary_html(meta, stored.rows)
+            if summary_html:
+                stored.summary_html = summary_html
+                updated_state = True
+
+        html_content = summary_html or "<p><em>Geen voorvertoning beschikbaar.</em></p>"
+        if updated_state:
+            _save_state()
         return {
             "mediaType": "text/html",
-            "html": html,
+            "html": html_content,
             "filename": meta.bestand,
+            "isEmbeddable": False,
         }
 
-    return {
+    if summary_html is None:
+        summary_html = _build_summary_html(meta, stored.rows)
+        if summary_html:
+            stored.summary_html = summary_html
+            updated_state = True
+
+    if updated_state:
+        _save_state()
+
+    response: dict[str, Any] = {
         "mediaType": media_type or "application/octet-stream",
         "url": f"/api/docs/{file_id}/content?inline=1",
         "filename": meta.bestand,
+        "isEmbeddable": True,
     }
+    if summary_html:
+        response["summaryHtml"] = summary_html
+    return response
 
 @app.post("/api/uploads", response_model=DocMeta)
 async def upload_doc(file: UploadFile = File(...)):
@@ -322,6 +557,22 @@ async def upload_doc(file: UploadFile = File(...)):
         final_path.unlink()
     temp_path.rename(final_path)
 
-    DOCS[meta.fileId] = StoredDoc(meta=meta, rows=rows)
+    meta.hasSource = True
+    summary_html: Optional[str] = None
+    try:
+        if final_path.suffix.lower() == ".docx":
+            summary_html = _docx_to_html(final_path)
+        else:
+            summary_html = _build_summary_html(meta, rows)
+    except HTTPException as exc:  # pragma: no cover - defensief
+        logger.warning(
+            "Kon voorvertoning niet genereren voor %s: %s",
+            file.filename,
+            getattr(exc, "detail", exc),
+        )
+        if summary_html is None:
+            summary_html = _build_summary_html(meta, rows)
+
+    DOCS[meta.fileId] = StoredDoc(meta=meta, rows=rows, summary_html=summary_html)
     _save_state()
     return meta

--- a/backend/models.py
+++ b/backend/models.py
@@ -14,6 +14,7 @@ class DocMeta(BaseModel):
     beginWeek: int
     eindWeek: int
     schooljaar: Optional[str] = None  # bv. "2025/2026"
+    hasSource: bool = True
 
 class WeekItem(BaseModel):
     week: int
@@ -26,16 +27,16 @@ class WeekItem(BaseModel):
 
 
 class DocRow(BaseModel):
-    week: Optional[int]
-    datum: Optional[str]
-    les: Optional[str]
-    onderwerp: Optional[str]
-    leerdoelen: Optional[List[str]]
-    huiswerk: Optional[str]
-    opdracht: Optional[str]
-    inleverdatum: Optional[str]
-    toets: Optional[Dict[str, Optional[str]]]
-    bronnen: Optional[List[Dict[str, str]]]
-    notities: Optional[str]
-    klas_of_groep: Optional[str]
-    locatie: Optional[str]
+    week: Optional[int] = None
+    datum: Optional[str] = None
+    les: Optional[str] = None
+    onderwerp: Optional[str] = None
+    leerdoelen: Optional[List[str]] = None
+    huiswerk: Optional[str] = None
+    opdracht: Optional[str] = None
+    inleverdatum: Optional[str] = None
+    toets: Optional[Dict[str, Optional[str]]] = None
+    bronnen: Optional[List[Dict[str, str]]] = None
+    notities: Optional[str] = None
+    klas_of_groep: Optional[str] = None
+    locatie: Optional[str] = None

--- a/backend/parsers/models.py
+++ b/backend/parsers/models.py
@@ -13,6 +13,7 @@ class DocMeta(BaseModel):
     beginWeek: int
     eindWeek: int
     schooljaar: Optional[str] = None  # bv. "2025/2026"
+    hasSource: bool = True
 
 # WeekItem kun je later via een aparte endpoint leveren
 class WeekItem(BaseModel):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -44,6 +44,6 @@ typer==0.17.4
 typing-inspection==0.4.1
 typing_extensions==4.15.0
 ujson==5.11.0
-uvicorn==0.30.1
+uvicorn[standard]==0.30.1
 watchfiles==1.1.0
 websockets==15.0.1

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8,6 +8,7 @@ export type DocMeta = {
   beginWeek: number;
   eindWeek: number;
   schooljaar?: string | null;
+  hasSource?: boolean | null;
 };
 
 export type DocToets = {
@@ -84,6 +85,8 @@ export type DocPreview = {
   url?: string;
   html?: string;
   filename?: string;
+  summaryHtml?: string;
+  isEmbeddable?: boolean;
 };
 
 export async function apiGetDocPreview(fileId: string): Promise<DocPreview> {

--- a/frontend/src/pages/Uploads.tsx
+++ b/frontend/src/pages/Uploads.tsx
@@ -242,13 +242,19 @@ export default function Uploads() {
         {filtered.length === 0 ? (
           <div className="p-6 text-sm theme-muted">Geen documenten gevonden.</div>
         ) : (
-          filtered.map((d, i) => (
-            <div
-              key={d.fileId}
-              className={`grid ${gridTemplate} gap-2 text-sm items-center px-4 py-3 ${
-                i > 0 ? "border-t theme-border" : ""
-              }`}
-            >
+          filtered.map((d, i) => {
+            const hasSource = d.hasSource ?? true;
+            const previewTitle = hasSource
+              ? `Bron: ${d.bestand}`
+              : "Samenvatting openen (originele bron ontbreekt)";
+
+            return (
+              <div
+                key={d.fileId}
+                className={`grid ${gridTemplate} gap-2 text-sm items-center px-4 py-3 ${
+                  i > 0 ? "border-t theme-border" : ""
+                }`}
+              >
               <div className="flex justify-center">
                 <input
                   type="checkbox"
@@ -278,7 +284,7 @@ export default function Uploads() {
               <div>{d.eindWeek}</div>
               <div className="flex gap-2 col-span-2">
                 <button
-                  title={`Bron: ${d.bestand}`}
+                  title={previewTitle}
                   className="rounded-lg border theme-border theme-surface p-1"
                   onClick={() => openPreview({ fileId: d.fileId, filename: d.bestand })}
                 >
@@ -299,8 +305,9 @@ export default function Uploads() {
                   <Trash2 size={16} />
                 </button>
               </div>
-            </div>
-          ))
+              </div>
+            );
+          })
         )}
       </div>
 

--- a/tests/test_preview_fallback.py
+++ b/tests/test_preview_fallback.py
@@ -1,0 +1,140 @@
+import sys
+from pathlib import Path
+
+from contextlib import contextmanager
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import backend.models as backend_models  # noqa: E402
+
+sys.modules.setdefault("models", backend_models)
+
+import backend.parsers as backend_parsers  # noqa: E402
+
+sys.modules.setdefault("parsers", backend_parsers)
+
+from fastapi.testclient import TestClient
+
+import backend.app as app_module
+from backend.models import DocMeta, DocRow
+
+
+@contextmanager
+def _setup_isolated_storage(tmp_path):
+    original_storage = app_module.STORAGE
+    original_state = app_module.STATE_FILE
+    app_module.STORAGE = tmp_path / "uploads"
+    app_module.STORAGE.mkdir(parents=True, exist_ok=True)
+    app_module.STATE_FILE = tmp_path / "state.json"
+    app_module.DOCS.clear()
+    try:
+        yield
+    finally:
+        app_module.DOCS.clear()
+        app_module.STORAGE = original_storage
+        app_module.STATE_FILE = original_state
+
+
+def test_preview_returns_summary_when_source_missing(tmp_path):
+    with _setup_isolated_storage(tmp_path):
+        client = TestClient(app_module.app)
+        meta = DocMeta(
+            fileId="abc123",
+            bestand="planner.pdf",
+            vak="Wiskunde",
+            niveau="VWO",
+            leerjaar="5",
+            periode=2,
+            beginWeek=3,
+            eindWeek=6,
+        )
+        row = DocRow(
+            week=3,
+            datum="2024-02-01",
+            les="Les 1",
+            onderwerp="Introductie",
+            leerdoelen=["Doel A"],
+        )
+        app_module.DOCS[meta.fileId] = app_module.StoredDoc(
+            meta=meta,
+            rows=[row],
+            summary_html="<p>Samenvatting</p>",
+        )
+
+        docs_response = client.get("/api/docs")
+        assert docs_response.status_code == 200
+        docs_payload = docs_response.json()
+        assert docs_payload[0]["hasSource"] is False
+
+        preview_response = client.get(f"/api/docs/{meta.fileId}/preview")
+        assert preview_response.status_code == 200
+        payload = preview_response.json()
+        assert payload["summaryHtml"].startswith("<p>")
+        assert payload["isEmbeddable"] is False
+        assert "url" not in payload
+
+
+def test_preview_generates_summary_from_rows(tmp_path):
+    with _setup_isolated_storage(tmp_path):
+        client = TestClient(app_module.app)
+        meta = DocMeta(
+            fileId="def456",
+            bestand="legacy.pdf",
+            vak="Natuurkunde",
+            niveau="HAVO",
+            leerjaar="4",
+            periode=1,
+            beginWeek=1,
+            eindWeek=4,
+        )
+        row = DocRow(
+            week=1,
+            datum="2024-01-15",
+            onderwerp="Krachten",
+            huiswerk="Lees hoofdstuk 1",
+        )
+        app_module.DOCS[meta.fileId] = app_module.StoredDoc(
+            meta=meta,
+            rows=[row],
+            summary_html=None,
+        )
+
+        response = client.get(f"/api/docs/{meta.fileId}/preview")
+        assert response.status_code == 200
+        data = response.json()
+        assert "summaryHtml" in data
+        assert "Krachten" in data["summaryHtml"]
+        assert data["isEmbeddable"] is False
+        assert app_module.DOCS[meta.fileId].summary_html is not None
+
+
+def test_preview_includes_url_when_source_available(tmp_path):
+    with _setup_isolated_storage(tmp_path):
+        client = TestClient(app_module.app)
+        meta = DocMeta(
+            fileId="ghi789",
+            bestand="planner.pdf",
+            vak="Geschiedenis",
+            niveau="VWO",
+            leerjaar="6",
+            periode=3,
+            beginWeek=10,
+            eindWeek=12,
+        )
+        row = DocRow(week=10, onderwerp="Hoofdstuk 5")
+        pdf_path = app_module.STORAGE / f"{meta.fileId}.pdf"
+        pdf_path.write_bytes(b"%PDF-1.4")
+        app_module.DOCS[meta.fileId] = app_module.StoredDoc(
+            meta=meta,
+            rows=[row],
+            summary_html="<p>Samenvatting</p>",
+        )
+
+        response = client.get(f"/api/docs/{meta.fileId}/preview")
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["isEmbeddable"] is True
+        assert payload["url"].endswith("/content?inline=1")
+        assert payload["summaryHtml"].startswith("<p>")


### PR DESCRIPTION
## Summary
- keep iframe previews preferred when available so summary HTML is only rendered as a fallback

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb415c3f708322a290006280ec43c7