### PR TITLE
Align matrix custom homework button with bottom of cell

### DIFF
--- a/frontend/src/pages/Matrix.tsx
+++ b/frontend/src/pages/Matrix.tsx
@@ -513,7 +513,7 @@ function MatrixCell({
         {!adding && !editing && (
           <button
             type="button"
-            className="flex items-center gap-1 text-xs text-slate-500 hover:text-slate-900"
+            className="mt-auto flex items-center gap-1 text-xs text-slate-500 hover:text-slate-900"
             onClick={startAdd}
             title="Eigen huiswerk toevoegen"
             aria-label={`Voeg huiswerk toe voor ${vak}`}


### PR DESCRIPTION
## Summary
- ensure the "Eigen huiswerk toevoegen" button in the matrix view sticks to the bottom of the cell by adding automatic top margin

## Testing
- `npm run build` *(fails: missing optional rollup dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc63b393948322b2a34c8294dc5741