### PR TITLE
Align matrix custom homework button with bottom of cell

### DIFF
--- a/frontend/src/pages/Matrix.tsx
+++ b/frontend/src/pages/Matrix.tsx
@@ -263,8 +263,8 @@ function MatrixCell({
   };
 
   return (
-    <td className="h-full px-4 py-2 align-top">
-      <div className="flex h-full min-w-[14rem] flex-col gap-2">
+    <td className="relative h-full px-4 py-2 align-top">
+      <div className="flex h-full min-w-[14rem] flex-col gap-2 pb-8">
         <div className="flex flex-wrap items-center gap-2 text-xs theme-muted">
           {hasOpmerkingen && (
             <span
@@ -510,19 +510,19 @@ function MatrixCell({
             </form>
           )}
         </div>
-        {!adding && !editing && (
-          <button
-            type="button"
-            className="flex items-center gap-1 text-xs text-slate-500 hover:text-slate-900"
-            onClick={startAdd}
-            title="Eigen huiswerk toevoegen"
-            aria-label={`Voeg huiswerk toe voor ${vak}`}
-          >
-            <Plus size={14} />
-            <span>Eigen huiswerk toevoegen</span>
-          </button>
-        )}
       </div>
+      {!adding && !editing && (
+        <button
+          type="button"
+          className="absolute bottom-2 left-4 flex items-center gap-1 text-xs text-slate-500 hover:text-slate-900"
+          onClick={startAdd}
+          title="Eigen huiswerk toevoegen"
+          aria-label={`Voeg huiswerk toe voor ${vak}`}
+        >
+          <Plus size={14} />
+          <span>Eigen huiswerk toevoegen</span>
+        </button>
+      )}
     </td>
   );
 }


### PR DESCRIPTION
## Summary
- make each matrix cell relative and pad the content so the "Eigen huiswerk toevoegen" button can be anchored
- absolutely position the add-custom-homework button at the bottom of the cell so it aligns with other views

## Testing
- `npm run build` *(fails: missing optional rollup dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc63b393948322b2a34c8294dc5741