### PR TITLE
Ensure matrix custom homework button stays anchored at bottom

### DIFF
--- a/frontend/src/pages/Matrix.tsx
+++ b/frontend/src/pages/Matrix.tsx
@@ -513,7 +513,7 @@ function MatrixCell({
         {!adding && !editing && (
           <button
             type="button"
-            className="flex items-center gap-1 text-xs text-slate-500 hover:text-slate-900"
+            className="mt-auto pt-2 flex items-center gap-1 text-xs text-slate-500 hover:text-slate-900"
             onClick={startAdd}
             title="Eigen huiswerk toevoegen"
             aria-label={`Voeg huiswerk toe voor ${vak}`}


### PR DESCRIPTION
## Summary
- keep matrix table cells as flex column containers rather than positioning relative
- move the "Eigen huiswerk toevoegen" button into the flex flow with an auto top margin so it rests against the cell bottom

## Testing
- `npm run build --prefix frontend` *(fails: missing optional Rollup native dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc63b393948322b2a34c8294dc5741