### PR TITLE
Add settings toggles for homework editing controls

### DIFF
--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -101,6 +101,10 @@ type State = {
   surfaceOpacity: number;
   setSurfaceOpacity: (value: number) => void;
   resetSurfaceOpacity: () => void;
+  enableHomeworkEditing: boolean;
+  setEnableHomeworkEditing: (value: boolean) => void;
+  enableCustomHomework: boolean;
+  setEnableCustomHomework: (value: boolean) => void;
 
   // ==== afvinkstatus gedeeld ====
   doneMap: Record<string, boolean>;
@@ -375,6 +379,8 @@ const createInitialState = (): Pick<
   | "theme"
   | "backgroundImage"
   | "surfaceOpacity"
+  | "enableHomeworkEditing"
+  | "enableCustomHomework"
   | "doneMap"
   | "weekIdxWO"
   | "niveauWO"
@@ -394,6 +400,8 @@ const createInitialState = (): Pick<
   theme: { ...defaultTheme },
   backgroundImage: null,
   surfaceOpacity: 100,
+  enableHomeworkEditing: true,
+  enableCustomHomework: true,
   doneMap: {},
   weekIdxWO: 0,
   niveauWO: "ALLE",
@@ -673,6 +681,10 @@ export const useAppStore = create<State>()(
           return { surfaceOpacity: clamped };
         }),
       resetSurfaceOpacity: () => set({ surfaceOpacity: 100 }),
+      setEnableHomeworkEditing: (value) =>
+        set(() => ({ enableHomeworkEditing: !!value })),
+      setEnableCustomHomework: (value) =>
+        set(() => ({ enableCustomHomework: !!value })),
 
       // ----------------------------
       // done-map
@@ -741,6 +753,8 @@ export const useAppStore = create<State>()(
         theme: state.theme,
         backgroundImage: state.backgroundImage,
         surfaceOpacity: state.surfaceOpacity,
+        enableHomeworkEditing: state.enableHomeworkEditing,
+        enableCustomHomework: state.enableCustomHomework,
         doneMap: state.doneMap,
         weekIdxWO: state.weekIdxWO,
         niveauWO: state.niveauWO,

--- a/frontend/src/pages/Matrix.tsx
+++ b/frontend/src/pages/Matrix.tsx
@@ -77,6 +77,8 @@ function MatrixCell({
   const overrideHomeworkItem = useAppStore((s) => s.overrideHomeworkItem);
   const clearHomeworkOverride = useAppStore((s) => s.clearHomeworkOverride);
   const updateCustomHomework = useAppStore((s) => s.updateCustomHomework);
+  const enableHomeworkEditing = useAppStore((s) => s.enableHomeworkEditing);
+  const enableCustomHomework = useAppStore((s) => s.enableCustomHomework);
   const storedItems =
     Array.isArray(data?.huiswerkItems) && data?.huiswerkItems.length
       ? data.huiswerkItems
@@ -186,6 +188,9 @@ function MatrixCell({
   const hasCustomItems = customItems.length > 0;
 
   const startAdd = () => {
+    if (!enableCustomHomework) {
+      return;
+    }
     setEditing(null);
     setEditText("");
     setAdding(true);
@@ -198,6 +203,9 @@ function MatrixCell({
 
   const submitCustom = (event: React.FormEvent) => {
     event.preventDefault();
+    if (!enableCustomHomework) {
+      return;
+    }
     const trimmed = customText.trim();
     if (!hasMeaningfulContent(trimmed)) {
       return;
@@ -213,6 +221,9 @@ function MatrixCell({
   };
 
   const startEditItem = (item: MatrixItem) => {
+    if (!enableHomeworkEditing) {
+      return;
+    }
     if (item.isCustom && !item.entryId) {
       return;
     }
@@ -227,7 +238,7 @@ function MatrixCell({
 
   const submitEdit = (event: React.FormEvent) => {
     event.preventDefault();
-    if (!editing) return;
+    if (!enableHomeworkEditing || !editing) return;
     const trimmed = editText.trim();
     if (!hasMeaningfulContent(trimmed)) {
       return;
@@ -245,6 +256,9 @@ function MatrixCell({
   };
 
   const handleRemoveItem = (item: MatrixItem) => {
+    if (!enableHomeworkEditing) {
+      return;
+    }
     if (item.isCustom && item.entryId) {
       onRemoveCustom(item.entryId);
     } else {
@@ -261,6 +275,20 @@ function MatrixCell({
       cancelEdit();
     }
   };
+
+  React.useEffect(() => {
+    if (!enableCustomHomework) {
+      setAdding(false);
+      setCustomText("");
+    }
+  }, [enableCustomHomework]);
+
+  React.useEffect(() => {
+    if (!enableHomeworkEditing) {
+      setEditing(null);
+      setEditText("");
+    }
+  }, [enableHomeworkEditing]);
 
   return (
     <td className="relative h-full px-4 py-2 align-top">
@@ -326,26 +354,28 @@ function MatrixCell({
                           {item.text}
                         </span>
                       </label>
-                      <div className="flex items-center gap-1">
-                        <button
-                          type="button"
-                          className="theme-muted hover:text-slate-700"
-                          onClick={() => startEditItem(item)}
-                          aria-label={`Bewerk huiswerk voor ${vak}`}
-                          title="Bewerk huiswerk"
-                        >
-                          <Pencil size={14} />
-                        </button>
-                        <button
-                          type="button"
-                          className="theme-muted hover:text-rose-600"
-                          onClick={() => handleRemoveItem(item)}
-                          aria-label={`Verwijder huiswerk voor ${vak}`}
-                          title="Verwijder huiswerk"
-                        >
-                          <Trash2 size={14} />
-                        </button>
-                      </div>
+                      {enableHomeworkEditing && (
+                        <div className="flex items-center gap-1">
+                          <button
+                            type="button"
+                            className="theme-muted hover:text-slate-700"
+                            onClick={() => startEditItem(item)}
+                            aria-label={`Bewerk huiswerk voor ${vak}`}
+                            title="Bewerk huiswerk"
+                          >
+                            <Pencil size={14} />
+                          </button>
+                          <button
+                            type="button"
+                            className="theme-muted hover:text-rose-600"
+                            onClick={() => handleRemoveItem(item)}
+                            aria-label={`Verwijder huiswerk voor ${vak}`}
+                            title="Verwijder huiswerk"
+                          >
+                            <Trash2 size={14} />
+                          </button>
+                        </div>
+                      )}
                     </li>
                   ))}
                 </ul>
@@ -399,28 +429,30 @@ function MatrixCell({
                             {item.text}
                           </span>
                         </label>
-                        <div className="flex items-center gap-1">
-                          <button
-                            type="button"
-                            className="theme-muted hover:text-slate-700"
-                            onClick={() => startEditItem(item)}
-                            aria-label={`Bewerk huiswerk voor ${vak}`}
-                            title="Bewerk huiswerk"
-                          >
-                            <Pencil size={14} />
-                          </button>
-                          {item.entryId && (
+                        {enableHomeworkEditing && (
+                          <div className="flex items-center gap-1">
                             <button
                               type="button"
-                              className="theme-muted hover:text-rose-600"
-                              onClick={() => handleRemoveItem(item)}
-                              aria-label={`Verwijder huiswerk voor ${vak}`}
-                              title="Verwijder huiswerk"
+                              className="theme-muted hover:text-slate-700"
+                              onClick={() => startEditItem(item)}
+                              aria-label={`Bewerk huiswerk voor ${vak}`}
+                              title="Bewerk huiswerk"
                             >
-                              <Trash2 size={14} />
+                              <Pencil size={14} />
                             </button>
-                          )}
-                        </div>
+                            {item.entryId && (
+                              <button
+                                type="button"
+                                className="theme-muted hover:text-rose-600"
+                                onClick={() => handleRemoveItem(item)}
+                                aria-label={`Verwijder huiswerk voor ${vak}`}
+                                title="Verwijder huiswerk"
+                              >
+                                <Trash2 size={14} />
+                              </button>
+                            )}
+                          </div>
+                        )}
                       </li>
                     ))}
                   </ul>
@@ -455,7 +487,7 @@ function MatrixCell({
               </ul>
             </div>
           )}
-          {editing && (
+          {editing && enableHomeworkEditing && (
             <form onSubmit={submitEdit} className="flex flex-col gap-2 text-xs">
               <textarea
                 className="w-full rounded-md border theme-border px-2 py-1"
@@ -482,7 +514,7 @@ function MatrixCell({
               </div>
             </form>
           )}
-          {adding && (
+          {adding && enableCustomHomework && (
             <form onSubmit={submitCustom} className="flex flex-col gap-2 text-xs">
               <textarea
                 className="w-full rounded-md border theme-border px-2 py-1"
@@ -511,7 +543,7 @@ function MatrixCell({
           )}
         </div>
       </div>
-      {!adding && !editing && (
+      {!adding && !editing && enableCustomHomework && (
         <div className="pointer-events-none absolute inset-x-4 bottom-2 flex justify-start">
           <button
             type="button"

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -17,6 +17,10 @@ export default function Settings() {
     surfaceOpacity,
     setSurfaceOpacity,
     resetSurfaceOpacity,
+    enableHomeworkEditing,
+    setEnableHomeworkEditing,
+    enableCustomHomework,
+    setEnableCustomHomework,
     resetAppState,
   } = useAppStore();
   const docs = useAppStore((s) => s.docs) ?? [];
@@ -201,6 +205,37 @@ export default function Settings() {
               onChange={() => setHuiswerkWeergave("gecombineerd")}
             />
             <span>Alles als één regel met één vinkje</span>
+          </label>
+        </div>
+
+        <div className="mt-4 space-y-2">
+          <label className="flex items-start gap-3 rounded-md border theme-border theme-soft p-3">
+            <input
+              type="checkbox"
+              checked={enableHomeworkEditing}
+              onChange={(event) => setEnableHomeworkEditing(event.target.checked)}
+              className="mt-1"
+            />
+            <span className="flex-1 space-y-1">
+              <span className="text-sm font-medium theme-text">Bewerken en verwijderen toestaan</span>
+              <span className="text-xs leading-snug theme-muted">
+                Verberg de potlood- en prullenbakknoppen bij huiswerk wanneer dit is uitgeschakeld.
+              </span>
+            </span>
+          </label>
+          <label className="flex items-start gap-3 rounded-md border theme-border theme-soft p-3">
+            <input
+              type="checkbox"
+              checked={enableCustomHomework}
+              onChange={(event) => setEnableCustomHomework(event.target.checked)}
+              className="mt-1"
+            />
+            <span className="flex-1 space-y-1">
+              <span className="text-sm font-medium theme-text">Eigen huiswerk toevoegen</span>
+              <span className="text-xs leading-snug theme-muted">
+                Toon de knop om zelf extra huiswerkregels toe te voegen aan een week.
+              </span>
+            </span>
           </label>
         </div>
       </div>

--- a/frontend/src/pages/WeekOverview.tsx
+++ b/frontend/src/pages/WeekOverview.tsx
@@ -75,6 +75,8 @@ function Card({
   const overrideHomeworkItem = useAppStore((s) => s.overrideHomeworkItem);
   const clearHomeworkOverride = useAppStore((s) => s.clearHomeworkOverride);
   const updateCustomHomework = useAppStore((s) => s.updateCustomHomework);
+  const enableHomeworkEditing = useAppStore((s) => s.enableHomeworkEditing);
+  const enableCustomHomework = useAppStore((s) => s.enableCustomHomework);
   const storedItems =
     Array.isArray(data?.huiswerkItems) && data?.huiswerkItems.length
       ? data.huiswerkItems
@@ -184,6 +186,9 @@ function Card({
   const hasCustomItems = customItems.length > 0;
 
   const startAdd = () => {
+    if (!enableCustomHomework) {
+      return;
+    }
     setEditing(null);
     setEditText("");
     setAdding(true);
@@ -196,6 +201,9 @@ function Card({
 
   const submitCustom = (event: React.FormEvent) => {
     event.preventDefault();
+    if (!enableCustomHomework) {
+      return;
+    }
     const trimmed = customText.trim();
     if (!hasMeaningfulContent(trimmed)) {
       return;
@@ -211,6 +219,9 @@ function Card({
   };
 
   const startEditItem = (item: HomeworkItem) => {
+    if (!enableHomeworkEditing) {
+      return;
+    }
     if (item.isCustom && !item.entryId) {
       return;
     }
@@ -225,7 +236,7 @@ function Card({
 
   const submitEdit = (event: React.FormEvent) => {
     event.preventDefault();
-    if (!editing) return;
+    if (!enableHomeworkEditing || !editing) return;
     const trimmed = editText.trim();
     if (!hasMeaningfulContent(trimmed)) {
       return;
@@ -243,6 +254,9 @@ function Card({
   };
 
   const handleRemoveItem = (item: HomeworkItem) => {
+    if (!enableHomeworkEditing) {
+      return;
+    }
     if (item.isCustom && item.entryId) {
       onRemoveCustom(item.entryId);
     } else {
@@ -259,6 +273,20 @@ function Card({
       cancelEdit();
     }
   };
+
+  React.useEffect(() => {
+    if (!enableCustomHomework) {
+      setAdding(false);
+      setCustomText("");
+    }
+  }, [enableCustomHomework]);
+
+  React.useEffect(() => {
+    if (!enableHomeworkEditing) {
+      setEditing(null);
+      setEditText("");
+    }
+  }, [enableHomeworkEditing]);
 
   return (
     <div className="rounded-2xl border theme-border theme-surface shadow-sm p-4 flex h-full flex-col gap-3">
@@ -338,26 +366,28 @@ function Card({
                       {item.text}
                     </span>
                   </label>
-                  <div className="flex items-center gap-1">
-                    <button
-                      type="button"
-                      className="theme-muted hover:text-slate-700"
-                      onClick={() => startEditItem(item)}
-                      aria-label={`Bewerk huiswerk voor ${vak}`}
-                      title="Bewerk huiswerk"
-                    >
-                      <Pencil size={14} />
-                    </button>
-                    <button
-                      type="button"
-                      className="theme-muted hover:text-rose-600"
-                      onClick={() => handleRemoveItem(item)}
-                      aria-label={`Verwijder huiswerk voor ${vak}`}
-                      title="Verwijder huiswerk"
-                    >
-                      <Trash2 size={14} />
-                    </button>
-                  </div>
+                  {enableHomeworkEditing && (
+                    <div className="flex items-center gap-1">
+                      <button
+                        type="button"
+                        className="theme-muted hover:text-slate-700"
+                        onClick={() => startEditItem(item)}
+                        aria-label={`Bewerk huiswerk voor ${vak}`}
+                        title="Bewerk huiswerk"
+                      >
+                        <Pencil size={14} />
+                      </button>
+                      <button
+                        type="button"
+                        className="theme-muted hover:text-rose-600"
+                        onClick={() => handleRemoveItem(item)}
+                        aria-label={`Verwijder huiswerk voor ${vak}`}
+                        title="Verwijder huiswerk"
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    </div>
+                  )}
                 </li>
               ))}
             </ul>
@@ -411,28 +441,30 @@ function Card({
                         {item.text}
                       </span>
                     </label>
-                    <div className="flex items-center gap-1">
-                      <button
-                        type="button"
-                        className="theme-muted hover:text-slate-700"
-                        onClick={() => startEditItem(item)}
-                        aria-label={`Bewerk huiswerk voor ${vak}`}
-                        title="Bewerk huiswerk"
-                      >
-                        <Pencil size={14} />
-                      </button>
-                      {item.entryId && (
+                    {enableHomeworkEditing && (
+                      <div className="flex items-center gap-1">
                         <button
                           type="button"
-                          className="theme-muted hover:text-rose-600"
-                          onClick={() => handleRemoveItem(item)}
-                          aria-label={`Verwijder huiswerk voor ${vak}`}
-                          title="Verwijder huiswerk"
+                          className="theme-muted hover:text-slate-700"
+                          onClick={() => startEditItem(item)}
+                          aria-label={`Bewerk huiswerk voor ${vak}`}
+                          title="Bewerk huiswerk"
                         >
-                          <Trash2 size={14} />
+                          <Pencil size={14} />
                         </button>
-                      )}
-                    </div>
+                        {item.entryId && (
+                          <button
+                            type="button"
+                            className="theme-muted hover:text-rose-600"
+                            onClick={() => handleRemoveItem(item)}
+                            aria-label={`Verwijder huiswerk voor ${vak}`}
+                            title="Verwijder huiswerk"
+                          >
+                            <Trash2 size={14} />
+                          </button>
+                        )}
+                      </div>
+                    )}
                   </li>
                 ))}
               </ul>
@@ -469,7 +501,7 @@ function Card({
           </div>
         )}
   
-        {editing && (
+        {editing && enableHomeworkEditing && (
           <form onSubmit={submitEdit} className="flex flex-col gap-2 text-sm">
             <textarea
               className="w-full rounded-md border theme-border px-2 py-1"
@@ -497,7 +529,7 @@ function Card({
           </form>
         )}
   
-        {adding && (
+        {adding && enableCustomHomework && (
           <form onSubmit={submitCustom} className="flex flex-col gap-2 text-sm">
             <textarea
               className="w-full rounded-md border theme-border px-2 py-1"
@@ -526,7 +558,7 @@ function Card({
         )}
   
       </div>
-      {!adding && !editing && (
+      {!adding && !editing && enableCustomHomework && (
         <button
           type="button"
           className="flex items-center gap-1 text-sm text-slate-500 hover:text-slate-900"


### PR DESCRIPTION
## Summary
- add persisted store settings to toggle homework editing and custom homework availability
- expose the new switches on the settings page
- hide edit, delete and add homework controls in the week and matrix views when the switches are off

## Testing
- npm run build *(fails: rollup optional native binary @rollup/rollup-linux-x64-gnu unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc86dcba5483228f832eb21031a970