### PR TITLE
Improve document previews and metadata insights

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -304,10 +304,12 @@ def get_doc_preview(file_id: str):
 
     media_type, _ = mimetypes.guess_type(file_path.name)
     if suffix == ".docx":
-        html = _docx_to_html(file_path)
+        media_type = (
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        )
         return {
-            "mediaType": "text/html",
-            "html": html,
+            "mediaType": media_type,
+            "url": f"/api/docs/{file_id}/content?inline=1",
             "filename": meta.bestand,
         }
 

--- a/frontend/src/components/DocumentPreviewProvider.tsx
+++ b/frontend/src/components/DocumentPreviewProvider.tsx
@@ -58,7 +58,11 @@ export function DocumentPreviewProvider({
           const iframeUrl = result.url.startsWith("http")
             ? result.url
             : `${API_BASE}${result.url}`;
-          setPreview({ mediaType: result.mediaType, iframeUrl });
+          setPreview({
+            mediaType: result.mediaType,
+            iframeUrl,
+            html: result.html,
+          });
         } else {
           setError("Geen voorvertoning beschikbaar");
         }
@@ -103,6 +107,8 @@ export function DocumentPreviewProvider({
 
   const hasHtml = !!preview?.html;
 
+  const isDocxPreview = preview?.mediaType.includes("wordprocessingml");
+
   return (
     <DocumentPreviewContext.Provider value={value}>
       {children}
@@ -133,11 +139,28 @@ export function DocumentPreviewProvider({
                   dangerouslySetInnerHTML={{ __html: preview?.html || "" }}
                 />
               ) : preview?.iframeUrl ? (
-                <iframe
-                  title={doc.filename}
-                  src={preview.iframeUrl}
-                  className="h-[75vh] w-full"
-                />
+                isDocxPreview ? (
+                  <div className="space-y-3 px-6 py-5 text-sm">
+                    <p className="theme-text">
+                      Voor DOCX-bestanden tonen we de originele inhoud. Download of open het
+                      document om de volledige opmaak te bekijken.
+                    </p>
+                    <a
+                      href={preview.iframeUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center justify-center rounded-md border theme-border bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    >
+                      Open origineel
+                    </a>
+                  </div>
+                ) : (
+                  <iframe
+                    title={doc.filename}
+                    src={preview.iframeUrl}
+                    className="h-[75vh] w-full"
+                  />
+                )
               ) : (
                 <div className="p-6 text-sm theme-muted">Geen voorvertoning beschikbaar.</div>
               )}


### PR DESCRIPTION
## Summary
- serve DOCX previews as the original document and update the preview dialog with a download option
- harden DOCX week extraction by keeping week order and stopping at new periods to avoid duplicate cycles
- enrich the uploads detail modal with extracted rows, aggregated deadlines/toetsen, and auto-loading of row data

## Testing
- pytest
- npm run build
- python tools/parse_demo.py samples

------
https://chatgpt.com/codex/tasks/task_e_68cdcc6f17b4832283769489a3db74fa