### PR TITLE
Voeg paginering en uploadtijd toe aan uploadsbeheer

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -14,6 +14,7 @@ class DocMeta(BaseModel):
     beginWeek: int
     eindWeek: int
     schooljaar: Optional[str] = None  # bv. "2025/2026"
+    uploadedAt: Optional[str] = None  # ISO timestamp van uploadmoment
 
 class WeekItem(BaseModel):
     week: int

--- a/backend/parsers/models.py
+++ b/backend/parsers/models.py
@@ -13,6 +13,7 @@ class DocMeta(BaseModel):
     beginWeek: int
     eindWeek: int
     schooljaar: Optional[str] = None  # bv. "2025/2026"
+    uploadedAt: Optional[str] = None  # ISO timestamp van uploadmoment
 
 # WeekItem kun je later via een aparte endpoint leveren
 class WeekItem(BaseModel):

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8,6 +8,7 @@ export type DocMeta = {
   beginWeek: number;
   eindWeek: number;
   schooljaar?: string | null;
+  uploadedAt?: string | null;
 };
 
 export type DocToets = {


### PR DESCRIPTION
## Summary
- sla het uploadmoment op in de doc-metadata en geef de API-lijst terug van nieuw naar oud
- toon de uploaddatum in de uploads-tabel met paginering van tien items per pagina
- sorteer documenten in de frontend-store op uploadmoment zodat nieuwe uploads bovenaan verschijnen

## Testing
- pytest
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cde3e4b9cc83229990e5bee26c7c23