### PR TITLE
Support multi-period DOCX parsing and upload

### DIFF
--- a/backend/parsers/__init__.py
+++ b/backend/parsers/__init__.py
@@ -1,5 +1,9 @@
 # eenvoudige re-export, met absolute imports intern
-from .parser_docx import extract_meta_from_docx, extract_rows_from_docx
+from .parser_docx import (
+    extract_meta_from_docx,
+    extract_rows_from_docx,
+    extract_all_periods_from_docx,
+)
 
 try:  # pragma: no cover
     from .parser_pdf import extract_meta_from_pdf, extract_rows_from_pdf

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -73,7 +73,7 @@ export async function apiDeleteAllDocs(): Promise<void> {
   if (!r.ok) throw new Error(`delete_all_docs failed: ${r.status}`);
 }
 
-export async function apiUploadDoc(file: File): Promise<DocMeta> {
+export async function apiUploadDoc(file: File): Promise<DocMeta[]> {
   const fd = new FormData();
   fd.append("file", file);
   const r = await fetch(`${BASE}/api/uploads`, {

--- a/frontend/src/pages/Uploads.tsx
+++ b/frontend/src/pages/Uploads.tsx
@@ -216,10 +216,12 @@ export default function Uploads() {
     const errors: string[] = [];
     for (const file of Array.from(files)) {
       try {
-        const meta = await apiUploadDoc(file);
-        // Voeg direct toe aan globale store → Settings/Belangrijke events/Matrix overzicht volgen automatisch
-        addDoc(meta as any);
-        await hydrateDocRowsFromApi(meta.fileId);
+        const metas = await apiUploadDoc(file);
+        for (const meta of metas) {
+          // Voeg direct toe aan globale store → Settings/Belangrijke events/Matrix overzicht volgen automatisch
+          addDoc(meta as any);
+          await hydrateDocRowsFromApi(meta.fileId);
+        }
       } catch (e: any) {
         errors.push(`${file.name}: ${e?.message || "Upload mislukt"}`);
       }


### PR DESCRIPTION
## Summary
- add a shared parsing context for DOCX files and expose `extract_all_periods_from_docx` to return rows per periode
- store each detected periode as its own upload entry and copy the file per periode while returning all `DocMeta`s
- update the upload UI flow, parser CLI, and tests to handle multi-periode responses

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cea062918c8322900f25c615eebd06