### PR TITLE
Add logo to application header

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -68,7 +68,14 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
         style={{ backgroundColor: headerBackground }}
       >
         <div className="mx-auto max-w-6xl px-4 py-3 flex items-center gap-3">
-          <div className="text-xl font-semibold theme-text">Het Vlier Studiewijzer Planner</div>
+          <div className="flex items-center gap-2">
+            <img
+              src="/logo.png"
+              alt="Het Vlier Studiewijzer Planner"
+              className="h-10 w-10 rounded-md border border-white/20 object-contain shadow-sm"
+            />
+            <div className="text-xl font-semibold theme-text">Het Vlier Studiewijzer Planner</div>
+          </div>
           <nav className="ml-auto flex gap-1">
             <NavLink
               to="/"


### PR DESCRIPTION
## Summary
- display the new logo image in the application header
- keep the existing title text next to the logo with subtle styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ceaa07538c83228cb90dfc9098f8b1