### PR TITLE
Update Eigen taak wording across views

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Een planner voor studiewijzers van het voortgezet onderwijs. Upload een studiewi
 - **Uploads & instellingen** – beheer geüploade studiewijzers, zichtbare vakken en thema.
 
 ## Huiswerk beheren
-- Voeg eigen huiswerk toe via de knop _“Eigen huiswerk toevoegen”_ onder elke vaksectie.
+- Voeg eigen taken toe via de knop _“Eigen taak toevoegen”_ onder elke vaksectie.
 - Bewerk bestaande items (zowel automatisch geïmporteerd als eigen notities) of verwijder ze.
 
 ## Functionaliteit

--- a/frontend/src/pages/Matrix.tsx
+++ b/frontend/src/pages/Matrix.tsx
@@ -521,7 +521,7 @@ function MatrixCell({
                 rows={2}
                 value={customText}
                 onChange={(event) => setCustomText(event.target.value)}
-                placeholder="Eigen huiswerk"
+                placeholder="Eigen taak"
               />
               <div className="flex gap-2 justify-end">
                 <button
@@ -549,11 +549,11 @@ function MatrixCell({
             type="button"
             className="pointer-events-auto flex items-center gap-1 text-xs text-slate-500 hover:text-slate-900"
             onClick={startAdd}
-            title="Eigen huiswerk toevoegen"
-            aria-label={`Voeg huiswerk toe voor ${vak}`}
+            title="Eigen taak toevoegen"
+            aria-label={`Voeg taak toe voor ${vak}`}
           >
             <Plus size={14} />
-            <span>Eigen huiswerk toevoegen</span>
+            <span>Eigen taak toevoegen</span>
           </button>
         </div>
       )}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -231,9 +231,9 @@ export default function Settings() {
               className="mt-1"
             />
             <div className="flex-1">
-              <div className="text-sm font-medium theme-text">Eigen huiswerk toevoegen</div>
+              <div className="text-sm font-medium theme-text">Eigen taak toevoegen</div>
               <div className="text-xs leading-snug theme-muted">
-                Toon de knop om zelf extra huiswerkregels toe te voegen aan een week.
+                Toon de knop om zelf extra taakregels toe te voegen aan een week.
               </div>
             </div>
           </label>

--- a/frontend/src/pages/WeekOverview.tsx
+++ b/frontend/src/pages/WeekOverview.tsx
@@ -536,7 +536,7 @@ function Card({
               rows={2}
               value={customText}
               onChange={(event) => setCustomText(event.target.value)}
-              placeholder="Eigen huiswerk"
+              placeholder="Eigen taak"
             />
             <div className="flex gap-2 justify-end">
               <button
@@ -563,11 +563,11 @@ function Card({
           type="button"
           className="flex items-center gap-1 text-sm text-slate-500 hover:text-slate-900"
           onClick={startAdd}
-          title="Eigen huiswerk toevoegen"
-          aria-label={`Voeg huiswerk toe voor ${vak}`}
+          title="Eigen taak toevoegen"
+          aria-label={`Voeg taak toe voor ${vak}`}
         >
           <Plus size={16} className="h-4 w-4" />
-          <span>Eigen huiswerk toevoegen</span>
+          <span>Eigen taak toevoegen</span>
         </button>
       )}
 

--- a/src/Matrix.tsx
+++ b/src/Matrix.tsx
@@ -5,7 +5,7 @@ const Matrix = () => {
         <div>
             {/* Other components */}
             {/* Ensure only one 'Add homework' button is present */}
-            <button onClick={handleAddHomework}>+ Eigen huiswerk toevoegen</button>
+            <button onClick={handleAddHomework}>+ Eigen taak toevoegen</button>
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- update manual task addition labels in WeekOverview and Matrix to say "Eigen taak"
- adjust the corresponding settings description and placeholder strings for consistency
- refresh the README instructions to mention "Eigen taak toevoegen"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cebf81e6a08322bf5537995f5ef776