### PR TITLE
Restore app module for uvicorn

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,11 @@
+"""Compatibiliteitsmodule voor traditionele ``uvicorn`` commando's.
+
+Deze module bestaat om bestaande documentatie/commando's als
+``uvicorn app:app --reload`` te laten blijven werken nu de eigenlijke
+FastAPI-applicatie in ``backend.app`` leeft.
+"""
+
+from backend.app import app
+
+__all__ = ["app"]
+


### PR DESCRIPTION
## Summary
- add a small top-level `app.py` module that re-exports the FastAPI app from `backend.app`
- document why the compatibility shim exists so `uvicorn app:app` keeps working

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cec5525c60832295ecd9dcf826048e