### PR TITLE
Fix demo screenshot display on uitleg page

### DIFF
--- a/frontend/src/pages/Handleiding.tsx
+++ b/frontend/src/pages/Handleiding.tsx
@@ -149,11 +149,11 @@ export default function Handleiding() {
               key={screen.title}
               className="flex h-full flex-col overflow-hidden rounded-xl border theme-border theme-surface shadow-sm"
             >
-              <div className="relative h-48 border-b border-[var(--app-border)] bg-[var(--app-background)]">
+              <div className="relative aspect-[16/10] border-b border-[var(--app-border)] bg-[var(--app-background)]">
                 <img
                   src={screen.image}
                   alt={screen.imageAlt}
-                  className="h-full w-full object-cover"
+                  className="h-full w-full object-contain"
                   loading="lazy"
                 />
               </div>


### PR DESCRIPTION
## Summary
- adjust uitleg page demo screenshot container to keep full images visible
- switch demo screenshot rendering to object-contain to avoid cropping

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf0372398883228bbbd0ad976da0cc