### PR TITLE
Remove linux-specific rollup dependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,6 @@
         "zustand": "^5.0.8"
       },
       "devDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.50.2",
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
         "autoprefixer": "^10.4.20",
@@ -380,19 +379,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.50.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.2.tgz",
-      "integrity": "sha512-9Jie/At6qk70dNIcopcL4p+1UirusEtznpNtcq/u/C5cC4HBX7qSGsYIcG6bdxj15EYWhHiu02YvmdPzylIZlA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
       "os": [
         "linux"
       ]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,6 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "^4.50.2",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "autoprefixer": "^10.4.20",


### PR DESCRIPTION
## Summary
- remove the linux-only @rollup/rollup-linux-x64-gnu dev dependency from the frontend
- regenerate the package-lock to eliminate the platform-specific package

## Testing
- npm install

------
https://chatgpt.com/codex/tasks/task_e_68cf04424fb083228286b4fe8bdc74f8