### PR TITLE
Add file-based logging for packaged executable

### DIFF
--- a/run_app.py
+++ b/run_app.py
@@ -38,13 +38,13 @@ def _configure_logging() -> None:
         return
 
     file_handler.set_name(LOG_HANDLER_NAME)
-    file_handler.setLevel(logging.INFO)
+    file_handler.setLevel(logging.WARNING)
     file_handler.setFormatter(
         logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
     )
     root_logger.addHandler(file_handler)
-    if root_logger.level > logging.INFO:
-        root_logger.setLevel(logging.INFO)
+    if root_logger.level > logging.WARNING:
+        root_logger.setLevel(logging.WARNING)
 
     logging.getLogger(__name__).info("Logbestand: %s", log_path)
 

--- a/run_app.py
+++ b/run_app.py
@@ -1,14 +1,57 @@
 from __future__ import annotations
 
+import logging
 import os
+import sys
 import threading
 import webbrowser
 from pathlib import Path
 
 import uvicorn
 
+LOG_HANDLER_NAME = "vlier-planner-file"
+
+
+def _default_log_path() -> Path:
+    override = os.getenv("VLIER_LOG_FILE")
+    if override:
+        return Path(override).expanduser()
+
+    if getattr(sys, "frozen", False):
+        exe_path = Path(sys.executable).resolve()
+        return exe_path.parent / "vlier-planner.log"
+
+    return Path(__file__).resolve().parent / "vlier-planner.log"
+
+
+def _configure_logging() -> None:
+    root_logger = logging.getLogger()
+    if any(getattr(handler, "name", "") == LOG_HANDLER_NAME for handler in root_logger.handlers):
+        return
+
+    log_path = _default_log_path()
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        file_handler = logging.FileHandler(log_path, encoding="utf-8")
+    except Exception as exc:  # pragma: no cover - afhankelijk van IO
+        logging.getLogger(__name__).warning("Kon logbestand niet initialiseren: %s", exc)
+        return
+
+    file_handler.set_name(LOG_HANDLER_NAME)
+    file_handler.setLevel(logging.INFO)
+    file_handler.setFormatter(
+        logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+    )
+    root_logger.addHandler(file_handler)
+    if root_logger.level > logging.INFO:
+        root_logger.setLevel(logging.INFO)
+
+    logging.getLogger(__name__).info("Logbestand: %s", log_path)
+
+
 # Ensure the backend knows it should serve the built frontend before it is imported
 os.environ.setdefault("SERVE_FRONTEND", "1")
+_configure_logging()
 
 from backend import app as backend_app
 


### PR DESCRIPTION
## Summary
- add a reusable logging configuration that writes to a log file next to the executable
- fall back to an override via VLIER_LOG_FILE and ensure handlers are not duplicated
- initialise logging before importing the backend so startup logs are captured

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf286952c08322a78431c2a7d2b2d9