### PR TITLE
Highlight current week column in matrix view

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -4,23 +4,8 @@ import { Coffee } from "lucide-react";
 import packageJson from "../../../package.json";
 import { useAppStore } from "../../app/store";
 import { PUBLIC_LOGO } from "../../assets/images";
+import { clamp01, withAlpha } from "../../lib/color";
 import { useOnboardingTour } from "../OnboardingTour";
-
-const clamp01 = (value: number) => Math.min(1, Math.max(0, value));
-
-const hexToRgba = (color: string, alpha: number) => {
-  const match = color.match(/^#?([0-9a-f]{6})$/i);
-  if (!match) {
-    return color;
-  }
-  const hex = match[1];
-  const r = parseInt(hex.slice(0, 2), 16);
-  const g = parseInt(hex.slice(2, 4), 16);
-  const b = parseInt(hex.slice(4, 6), 16);
-  const normalized = clamp01(alpha);
-  const roundedAlpha = Math.round(normalized * 100) / 100;
-  return `rgba(${r}, ${g}, ${b}, ${roundedAlpha})`;
-};
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
   const theme = useAppStore((state) => state.theme);
@@ -31,7 +16,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
 
   const themeStyle = React.useMemo(() => {
     const surfaceAlpha = clamp01(surfaceOpacity / 100);
-    const resolvedSurface = hexToRgba(theme.surface, surfaceAlpha);
+    const resolvedSurface = withAlpha(theme.surface, surfaceAlpha);
     const base = {
       "--app-background": theme.background,
       "--app-surface": resolvedSurface,
@@ -60,7 +45,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   const headerBackground = React.useMemo(() => {
     const surfaceAlpha = clamp01(surfaceOpacity / 100);
     const headerAlpha = clamp01(surfaceAlpha * 0.6 + 0.2);
-    return hexToRgba(theme.surface, headerAlpha);
+    return withAlpha(theme.surface, headerAlpha);
   }, [theme.surface, surfaceOpacity]);
 
   const navigationLinks = React.useMemo(

--- a/frontend/src/lib/color.ts
+++ b/frontend/src/lib/color.ts
@@ -1,0 +1,60 @@
+export const clamp01 = (value: number) => Math.min(1, Math.max(0, value));
+
+const clampChannel = (value: number) => {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.min(255, Math.max(0, Math.round(value)));
+};
+
+const roundAlpha = (value: number) => {
+  const normalized = clamp01(value);
+  return Math.round(normalized * 100) / 100;
+};
+
+const expandShortHex = (hex: string) =>
+  hex
+    .split("")
+    .map((ch) => ch + ch)
+    .join("");
+
+export const withAlpha = (color: string, alpha: number) => {
+  if (!color) {
+    return color;
+  }
+  const trimmed = color.trim();
+  const roundedAlpha = roundAlpha(alpha);
+  const sixHexMatch = trimmed.match(/^#?([0-9a-f]{6})$/i);
+  if (sixHexMatch) {
+    const hex = sixHexMatch[1];
+    const r = parseInt(hex.slice(0, 2), 16);
+    const g = parseInt(hex.slice(2, 4), 16);
+    const b = parseInt(hex.slice(4, 6), 16);
+    return `rgba(${r}, ${g}, ${b}, ${roundedAlpha})`;
+  }
+  const threeHexMatch = trimmed.match(/^#?([0-9a-f]{3})$/i);
+  if (threeHexMatch) {
+    const expanded = expandShortHex(threeHexMatch[1]);
+    const r = parseInt(expanded.slice(0, 2), 16);
+    const g = parseInt(expanded.slice(2, 4), 16);
+    const b = parseInt(expanded.slice(4, 6), 16);
+    return `rgba(${r}, ${g}, ${b}, ${roundedAlpha})`;
+  }
+  const rgbMatch = trimmed.match(/^rgb\s*\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/i);
+  if (rgbMatch) {
+    const r = clampChannel(Number(rgbMatch[1]));
+    const g = clampChannel(Number(rgbMatch[2]));
+    const b = clampChannel(Number(rgbMatch[3]));
+    return `rgba(${r}, ${g}, ${b}, ${roundedAlpha})`;
+  }
+  const rgbaMatch = trimmed.match(
+    /^rgba\s*\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*([0-9]*\.?[0-9]+)\s*\)$/i,
+  );
+  if (rgbaMatch) {
+    const r = clampChannel(Number(rgbaMatch[1]));
+    const g = clampChannel(Number(rgbaMatch[2]));
+    const b = clampChannel(Number(rgbaMatch[3]));
+    return `rgba(${r}, ${g}, ${b}, ${roundedAlpha})`;
+  }
+  return trimmed;
+};

--- a/frontend/src/pages/Matrix.tsx
+++ b/frontend/src/pages/Matrix.tsx
@@ -27,6 +27,7 @@ import { splitHomeworkItems } from "../lib/textUtils";
 import { useDocumentPreview } from "../components/DocumentPreviewProvider";
 import { deriveIsoYearForWeek, makeWeekId } from "../lib/calendar";
 import { hasMeaningfulContent } from "../lib/contentUtils";
+import { withAlpha } from "../lib/color";
 
 type MatrixItem = {
   text: string;
@@ -53,6 +54,9 @@ function MatrixCell({
   customHomework,
   onAddCustom,
   onRemoveCustom,
+  isCurrentWeek,
+  highlightColor,
+  highlightBorderColor,
 }: {
   vak: string;
   week: WeekInfo;
@@ -65,6 +69,9 @@ function MatrixCell({
   customHomework: CustomHomeworkEntry[];
   onAddCustom: (text: string) => void;
   onRemoveCustom: (entryId: string) => void;
+  isCurrentWeek: boolean;
+  highlightColor: string;
+  highlightBorderColor?: string;
 }) {
   const [adding, setAdding] = React.useState(false);
   const [customText, setCustomText] = React.useState("");
@@ -290,8 +297,17 @@ function MatrixCell({
     }
   }, [enableHomeworkEditing]);
 
+  const highlightStyle: React.CSSProperties | undefined = isCurrentWeek
+    ? {
+        backgroundColor: highlightColor,
+        boxShadow: highlightBorderColor
+          ? `inset 1px 0 0 0 ${highlightBorderColor}, inset -1px 0 0 0 ${highlightBorderColor}`
+          : undefined,
+      }
+    : undefined;
+
   return (
-    <td className="relative h-full px-4 py-2 align-top">
+    <td className="relative h-full px-4 py-2 align-top" style={highlightStyle}>
       <div className="flex h-full min-w-[14rem] flex-col gap-2 pb-8">
         <div className="flex flex-wrap items-center gap-2 text-xs theme-muted">
           {hasOpmerkingen && (
@@ -579,6 +595,7 @@ export default function Matrix() {
   const setNiveau = useAppStore((s) => s.setMatrixNiveau);
   const leerjaar = useAppStore((s) => s.matrixLeerjaar);
   const setLeerjaar = useAppStore((s) => s.setMatrixLeerjaar);
+  const accentColor = useAppStore((s) => s.theme.accent);
   const { openPreview } = useDocumentPreview();
 
   const activeDocs = React.useMemo(() => docs.filter((d) => d.enabled), [docs]);
@@ -664,6 +681,17 @@ export default function Matrix() {
     return (weekData.weeks ?? []).filter((w) => allowed.has(w.id));
   }, [allowedWeekIdSet, weekData.weeks]);
 
+  const currentWeekIdx = React.useMemo(() => calcCurrentWeekIdx(allWeeks), [allWeeks]);
+  const currentWeekId = allWeeks[currentWeekIdx]?.id;
+  const currentWeekHighlightColor = React.useMemo(
+    () => withAlpha(accentColor, 0.12),
+    [accentColor],
+  );
+  const currentWeekBorderColor = React.useMemo(() => {
+    const resolved = withAlpha(accentColor, 0.28);
+    return resolved === accentColor ? undefined : resolved;
+  }, [accentColor]);
+
   const hasWeekData = allWeeks.length > 0;
   const disableWeekControls = !hasAnyDocs || !hasWeekData;
 
@@ -682,11 +710,10 @@ export default function Matrix() {
   };
   const goThisWeek = React.useCallback(() => {
     if (disableWeekControls) return;
-    const idx = calcCurrentWeekIdx(allWeeks);
-    const targetWeekId = allWeeks[idx]?.id;
+    const targetWeekId = allWeeks[currentWeekIdx]?.id;
     const start = computeWindowStartForWeek(allWeeks, count, targetWeekId);
     setStartIdx(start);
-  }, [allWeeks, count, disableWeekControls]);
+  }, [allWeeks, count, currentWeekIdx, disableWeekControls, setStartIdx]);
 
   React.useEffect(() => {
     if (disableWeekControls) {
@@ -830,12 +857,28 @@ export default function Matrix() {
             <thead className="theme-soft">
               <tr>
                 <th className="px-4 py-2 text-left whitespace-nowrap">Vak</th>
-                {weeks.map((w) => (
-                  <th key={w.id} className="px-4 py-2 text-left">
-                    <div className="font-medium">Week {w.nr}</div>
-                    <div className="text-xs theme-muted">{formatRange(w)}</div>
-                  </th>
-                ))}
+                {weeks.map((w) => {
+                  const isCurrent = w.id === currentWeekId;
+                  const headerStyle: React.CSSProperties | undefined = isCurrent
+                    ? {
+                        backgroundColor: currentWeekHighlightColor,
+                        boxShadow: currentWeekBorderColor
+                          ? `inset 0 -2px 0 0 ${currentWeekBorderColor}`
+                          : undefined,
+                      }
+                    : undefined;
+                  return (
+                    <th
+                      key={w.id}
+                      className="px-4 py-2 text-left"
+                      style={headerStyle}
+                      aria-current={isCurrent ? "true" : undefined}
+                    >
+                      <div className="font-medium">Week {w.nr}</div>
+                      <div className="text-xs theme-muted">{formatRange(w)}</div>
+                    </th>
+                  );
+                })}
               </tr>
             </thead>
             <tbody>
@@ -866,6 +909,9 @@ export default function Matrix() {
                         customHomework={customEntries}
                         onAddCustom={(text) => addCustomHomework(w.id, vak, text)}
                         onRemoveCustom={(entryId) => removeCustomHomework(w.id, vak, entryId)}
+                        isCurrentWeek={w.id === currentWeekId}
+                        highlightColor={currentWeekHighlightColor}
+                        highlightBorderColor={currentWeekBorderColor}
                       />
                     );
                   })}


### PR DESCRIPTION
## Summary
- add a reusable color helper to apply alpha values to theme colors
- highlight the current week column in the matrix overview with a subtle accent tint
- reuse the color helper in the app shell when computing translucent surfaces

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf2bc103ec83228c961ef35dbf1037