### PR TITLE
Align current week column when jumping to today

### DIFF
--- a/frontend/src/lib/weekUtils.ts
+++ b/frontend/src/lib/weekUtils.ts
@@ -118,13 +118,18 @@ export const calcCurrentWeekIdx = (weeks: WeekInfo[], today: Date = new Date()):
 export const computeWindowStartForWeek = (
   weeks: WeekInfo[],
   windowSize: number,
-  targetWeekId?: string
+  targetWeekId?: string,
+  options: { align?: "center" | "start" } = {}
 ) => {
   if (!weeks.length) return 0;
   const maxStart = Math.max(0, weeks.length - windowSize);
   if (!targetWeekId) return 0;
   const idx = weeks.findIndex((w) => w.id === targetWeekId);
   if (idx === -1) return 0;
+  const align = options.align ?? "center";
+  if (align === "start") {
+    return Math.max(0, Math.min(idx, maxStart));
+  }
   const desired = idx - Math.floor(windowSize / 2);
   return Math.max(0, Math.min(desired, maxStart));
 };

--- a/frontend/src/pages/Matrix.tsx
+++ b/frontend/src/pages/Matrix.tsx
@@ -708,12 +708,17 @@ export default function Matrix() {
     if (disableWeekControls) return;
     setStartIdx(Math.min(maxStart, clampedStart + 1));
   };
-  const goThisWeek = React.useCallback(() => {
-    if (disableWeekControls) return;
-    const targetWeekId = allWeeks[currentWeekIdx]?.id;
-    const start = computeWindowStartForWeek(allWeeks, count, targetWeekId);
-    setStartIdx(start);
-  }, [allWeeks, count, currentWeekIdx, disableWeekControls, setStartIdx]);
+  const goThisWeek = React.useCallback(
+    (align: "center" | "start" = "center") => {
+      if (disableWeekControls) return;
+      const targetWeekId = allWeeks[currentWeekIdx]?.id;
+      const start = computeWindowStartForWeek(allWeeks, count, targetWeekId, {
+        align,
+      });
+      setStartIdx(start);
+    },
+    [allWeeks, count, currentWeekIdx, disableWeekControls, setStartIdx]
+  );
 
   React.useEffect(() => {
     if (disableWeekControls) {
@@ -758,7 +763,7 @@ export default function Matrix() {
       </div>
       <div className="mb-4 flex flex-wrap gap-2 items-center">
         <button
-          onClick={goThisWeek}
+          onClick={() => goThisWeek("start")}
           className="rounded-md border theme-border theme-surface px-2 py-1 text-sm disabled:opacity-40 disabled:cursor-not-allowed"
           title="Spring naar huidige week"
           aria-label="Deze week"


### PR DESCRIPTION
## Summary
- allow computeWindowStartForWeek to align the selected week to the start of the window
- update the Matrix overzicht jump button so the current week becomes the first visible column

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf2ef4aee88322864bf2ffa584666a