### PR TITLE
Switch onboarding tour button to icon

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { NavLink } from "react-router-dom";
-import { Coffee } from "lucide-react";
+import { Coffee, Sparkles } from "lucide-react";
 import packageJson from "../../../package.json";
 import { useAppStore } from "../../app/store";
 import { PUBLIC_LOGO } from "../../assets/images";
@@ -91,10 +91,10 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
             <button
               type="button"
               onClick={() => restartTour()}
-              className={`${resolveLinkClassName(false)} whitespace-nowrap`}
+              className={`${resolveLinkClassName(false)} flex items-center justify-center !px-2 !py-2`}
               aria-label="Rondleiding opnieuw starten"
             >
-              Rondleiding
+              <Sparkles size={18} aria-hidden="true" />
             </button>
           </nav>
         </div>


### PR DESCRIPTION
## Summary
- replace the "Rondleiding" text button with a sparkles icon to make the tour control less prominent
- ensure the icon button remains centered and accessible via aria-label

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf31511d888322b4a787d81547ab85