### PR TITLE
Lighten onboarding tour overlay

### DIFF
--- a/frontend/src/components/OnboardingTour.tsx
+++ b/frontend/src/components/OnboardingTour.tsx
@@ -336,10 +336,10 @@ export function OnboardingTourProvider({ children }: { children: React.ReactNode
       {isActive && portalTarget && step
         ? createPortal(
             <div className="fixed inset-0 z-[9999]" aria-live="polite">
-              <div className="absolute inset-0 bg-slate-900/30" aria-hidden="true" />
+              <div className="absolute inset-0 bg-slate-900/70" aria-hidden="true" />
               {highlightStyle ? (
                 <div
-                  className="pointer-events-none absolute border-2 border-white/80 shadow-[0_0_0_9999px_rgba(15,23,42,0.22)]"
+                  className="pointer-events-none absolute border-2 border-white/90 bg-white/20 shadow-[0_0_0_9999px_rgba(15,23,42,0.6)] backdrop-blur-[1px]"
                   style={highlightStyle}
                   aria-hidden="true"
                 />

--- a/frontend/src/components/OnboardingTour.tsx
+++ b/frontend/src/components/OnboardingTour.tsx
@@ -336,10 +336,10 @@ export function OnboardingTourProvider({ children }: { children: React.ReactNode
       {isActive && portalTarget && step
         ? createPortal(
             <div className="fixed inset-0 z-[9999]" aria-live="polite">
-              <div className="absolute inset-0 bg-slate-900/70" aria-hidden="true" />
+              <div className="absolute inset-0 bg-slate-900/10" aria-hidden="true" />
               {highlightStyle ? (
                 <div
-                  className="pointer-events-none absolute border-2 border-white/90 bg-white/40 shadow-[0_0_0_9999px_rgba(15,23,42,0.6)]"
+                  className="pointer-events-none absolute border-2 border-white/90 shadow-[0_0_0_9999px_rgba(15,23,42,0.6)]"
                   style={highlightStyle}
                   aria-hidden="true"
                 />

--- a/frontend/src/components/OnboardingTour.tsx
+++ b/frontend/src/components/OnboardingTour.tsx
@@ -339,7 +339,7 @@ export function OnboardingTourProvider({ children }: { children: React.ReactNode
               <div className="absolute inset-0 bg-slate-900/70" aria-hidden="true" />
               {highlightStyle ? (
                 <div
-                  className="pointer-events-none absolute border-2 border-white/90 bg-white/20 shadow-[0_0_0_9999px_rgba(15,23,42,0.6)] backdrop-blur-[1px]"
+                  className="pointer-events-none absolute border-2 border-white/90 bg-white/40 shadow-[0_0_0_9999px_rgba(15,23,42,0.6)]"
                   style={highlightStyle}
                   aria-hidden="true"
                 />

--- a/frontend/src/components/OnboardingTour.tsx
+++ b/frontend/src/components/OnboardingTour.tsx
@@ -336,10 +336,10 @@ export function OnboardingTourProvider({ children }: { children: React.ReactNode
       {isActive && portalTarget && step
         ? createPortal(
             <div className="fixed inset-0 z-[9999]" aria-live="polite">
-              <div className="absolute inset-0 bg-slate-900/40" aria-hidden="true" />
+              <div className="absolute inset-0 bg-slate-900/30" aria-hidden="true" />
               {highlightStyle ? (
                 <div
-                  className="pointer-events-none absolute border-2 border-white/90 shadow-[0_0_0_9999px_rgba(15,23,42,0.35)]"
+                  className="pointer-events-none absolute border-2 border-white/80 shadow-[0_0_0_9999px_rgba(15,23,42,0.22)]"
                   style={highlightStyle}
                   aria-hidden="true"
                 />

--- a/frontend/src/components/OnboardingTour.tsx
+++ b/frontend/src/components/OnboardingTour.tsx
@@ -336,10 +336,10 @@ export function OnboardingTourProvider({ children }: { children: React.ReactNode
       {isActive && portalTarget && step
         ? createPortal(
             <div className="fixed inset-0 z-[9999]" aria-live="polite">
-              <div className="absolute inset-0 bg-slate-900/70" aria-hidden="true" />
+              <div className="absolute inset-0 bg-slate-900/40" aria-hidden="true" />
               {highlightStyle ? (
                 <div
-                  className="pointer-events-none absolute border-2 border-white/90 shadow-[0_0_0_9999px_rgba(15,23,42,0.6)]"
+                  className="pointer-events-none absolute border-2 border-white/90 shadow-[0_0_0_9999px_rgba(15,23,42,0.35)]"
                   style={highlightStyle}
                   aria-hidden="true"
                 />


### PR DESCRIPTION
## Summary
- reduce the darkness of the onboarding tour backdrop to improve page visibility during the guide
- lighten the highlight shadow so surrounding content remains more visible

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68cfe237781c83229e0ce6c1fccd5a7a