### PR TITLE
Disable Uvicorn color logging for packaged app

### DIFF
--- a/tests/test_run_app_logging.py
+++ b/tests/test_run_app_logging.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import importlib
+
+
+def test_uvicorn_log_config_disables_colors(monkeypatch, tmp_path):
+    monkeypatch.setenv("VLIER_LOG_FILE", str(tmp_path / "vlier.log"))
+    run_app = importlib.import_module("run_app")
+
+    config = run_app.get_uvicorn_log_config()
+
+    assert config["formatters"]["default"]["use_colors"] is False
+    assert config["formatters"]["access"]["use_colors"] is False


### PR DESCRIPTION
## Summary
- create a helper that clones Uvicorn's logging configuration with color output disabled to avoid isatty() lookups when stdio streams are replaced
- ensure the application always uses the safe log configuration when starting Uvicorn
- add a regression test that verifies the default and access log formatters disable colors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cff61eca608322896eb4f542550282