### PR TITLE
Disable Uvicorn color logging for packaged app

### DIFF
--- a/run_app.py
+++ b/run_app.py
@@ -5,11 +5,39 @@ import os
 import sys
 import threading
 import webbrowser
+from copy import deepcopy
 from pathlib import Path
+from typing import Any
 
 import uvicorn
+from uvicorn.config import LOGGING_CONFIG
 
 LOG_HANDLER_NAME = "vlier-planner-file"
+LOG_LEVEL_ENV_VAR = "VLIER_LOG_LEVEL"
+
+
+def _get_configured_log_level(default: int = logging.WARNING) -> int:
+    """Resolve the desired log level from the environment."""
+
+    value = os.getenv(LOG_LEVEL_ENV_VAR)
+    if not value:
+        return default
+
+    value = value.strip()
+    if not value:
+        return default
+
+    # Allow numeric levels ("10") as well as textual levels ("DEBUG").
+    try:
+        numeric_level = int(value)
+    except ValueError:
+        level_name = value.upper()
+        resolved = getattr(logging, level_name, None)
+        if isinstance(resolved, int):
+            return resolved
+        return default
+    else:
+        return numeric_level
 
 
 def _default_log_path() -> Path:
@@ -38,15 +66,33 @@ def _configure_logging() -> None:
         return
 
     file_handler.set_name(LOG_HANDLER_NAME)
-    file_handler.setLevel(logging.WARNING)
+    log_level = _get_configured_log_level()
+
+    file_handler.setLevel(log_level)
     file_handler.setFormatter(
         logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
     )
     root_logger.addHandler(file_handler)
-    if root_logger.level > logging.WARNING:
-        root_logger.setLevel(logging.WARNING)
+    if root_logger.level > log_level:
+        root_logger.setLevel(log_level)
 
     logging.getLogger(__name__).info("Logbestand: %s", log_path)
+
+
+def get_uvicorn_log_config() -> dict[str, Any]:
+    """Return a logging configuration that avoids isatty() calls in Uvicorn."""
+
+    log_config: dict[str, Any] = deepcopy(LOGGING_CONFIG)
+    formatters = log_config.get("formatters", {})
+
+    for formatter_name in ("default", "access"):
+        formatter = formatters.get(formatter_name)
+        if isinstance(formatter, dict):
+            # Ensure Uvicorn does not call isatty() on replaced stdio streams.
+            formatter = {**formatter, "use_colors": False}
+            formatters[formatter_name] = formatter
+
+    return log_config
 
 
 # Ensure the backend knows it should serve the built frontend before it is imported
@@ -84,6 +130,7 @@ def main() -> None:
         host=host,
         port=port,
         log_level=os.getenv("UVICORN_LOG_LEVEL", "info"),
+        log_config=get_uvicorn_log_config(),
     )
 
 

--- a/tests/test_run_app_logging.py
+++ b/tests/test_run_app_logging.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _remove_log_handler() -> None:
+    root_logger = logging.getLogger()
+    for handler in list(root_logger.handlers):
+        if getattr(handler, "name", "") == "vlier-planner-file":
+            root_logger.removeHandler(handler)
+            handler.close()
+
+
+def _import_run_app():
+    existing = sys.modules.get("run_app")
+    if existing is not None:
+        return importlib.reload(existing)
+    return importlib.import_module("run_app")
+
+
+@pytest.fixture(autouse=True)
+def clean_logging_handlers():
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+    sys.modules.pop("run_app", None)
+    _remove_log_handler()
+    yield
+    _remove_log_handler()
+    sys.modules.pop("run_app", None)
+
+
+def test_uvicorn_log_config_disables_colors(monkeypatch, tmp_path):
+    monkeypatch.setenv("VLIER_LOG_FILE", str(tmp_path / "vlier.log"))
+    run_app = _import_run_app()
+
+    config = run_app.get_uvicorn_log_config()
+
+    assert config["formatters"]["default"]["use_colors"] is False
+    assert config["formatters"]["access"]["use_colors"] is False
+
+
+def test_file_log_level_can_be_configured(monkeypatch, tmp_path):
+    monkeypatch.setenv("VLIER_LOG_FILE", str(tmp_path / "vlier.log"))
+    monkeypatch.setenv("VLIER_LOG_LEVEL", "DEBUG")
+
+    _import_run_app()
+
+    root_logger = logging.getLogger()
+    handler_levels = {
+        handler.level
+        for handler in root_logger.handlers
+        if getattr(handler, "name", "") == "vlier-planner-file"
+    }
+
+    assert handler_levels == {logging.DEBUG}
+    assert root_logger.level == logging.DEBUG


### PR DESCRIPTION
## Summary
- create a helper that clones Uvicorn's logging configuration with color output disabled to avoid isatty() lookups when stdio streams are replaced
- ensure the application always uses the safe log configuration when starting Uvicorn
- add a regression test that verifies the default and access log formatters disable colors
- allow configuring the file log handler level via the VLIER_LOG_LEVEL environment variable and cover it with a test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cff61eca608322896eb4f542550282