### PR TITLE
Add auto-update capability

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -13,6 +13,7 @@ from typing import Any, List, Union, Tuple
 from urllib.parse import quote
 
 from fastapi import FastAPI, UploadFile, File, HTTPException
+from pydantic import BaseModel
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
@@ -44,6 +45,13 @@ except ImportError:  # pragma: no cover
         extract_meta_from_pdf,
         extract_rows_from_pdf,
     )
+
+try:  # pragma: no cover - fallback for legacy execution styles
+    from .version import APP_VERSION
+    from . import updater
+except ImportError:  # pragma: no cover
+    from version import APP_VERSION  # type: ignore
+    import updater  # type: ignore
 
 app = FastAPI(title="Vlier Planner API")
 
@@ -191,6 +199,73 @@ def _load_state() -> None:
 
 
 _load_state()
+
+
+class UpdateRequest(BaseModel):
+    version: str | None = None
+    silent: bool | None = None
+
+
+def _truncate_notes(text: str | None, limit: int = 2000) -> str | None:
+    if not text:
+        return None
+    trimmed = text.strip()
+    if len(trimmed) <= limit:
+        return trimmed
+    return trimmed[: limit - 3] + "..."
+
+
+@app.get("/api/system/version")
+def api_get_version() -> dict[str, str]:
+    return {"version": APP_VERSION}
+
+
+@app.get("/api/system/update")
+def api_check_update() -> dict[str, Any]:
+    try:
+        info = updater.check_for_update()
+    except updater.UpdateError as exc:
+        logger.warning("Update-check mislukt: %s", exc)
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    if info is None:
+        return {"updateAvailable": False, "currentVersion": APP_VERSION}
+
+    notes = _truncate_notes(info.release_notes)
+    return {
+        "updateAvailable": True,
+        "currentVersion": APP_VERSION,
+        "latestVersion": info.latest_version,
+        "assetName": info.asset_name,
+        "notes": notes,
+        "checksum": info.sha256,
+    }
+
+
+@app.post("/api/system/update")
+def api_install_update(payload: UpdateRequest) -> dict[str, Any]:
+    try:
+        info = updater.check_for_update()
+    except updater.UpdateError as exc:
+        logger.warning("Update-check mislukt tijdens installatie: %s", exc)
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    if info is None:
+        raise HTTPException(status_code=409, detail="Geen update beschikbaar")
+
+    if payload.version and payload.version != info.latest_version:
+        raise HTTPException(
+            status_code=409,
+            detail="De aangevraagde versie is niet meer beschikbaar",
+        )
+
+    try:
+        installer_path = updater.install_update(info, silent=payload.silent)
+    except updater.UpdateError as exc:
+        logger.warning("Installatie van update mislukt: %s", exc)
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return {"status": "started", "installerPath": str(installer_path)}
 
 # -----------------------------
 # Endpoints

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,6 +20,7 @@ lxml==6.0.1
 markdown-it-py==4.0.0
 MarkupSafe==3.0.2
 mdurl==0.1.2
+packaging==24.1
 orjson==3.11.3
 pdfminer.six==20250506
 pdfplumber==0.11.7

--- a/backend/updater.py
+++ b/backend/updater.py
@@ -1,0 +1,247 @@
+"""Utilities for checking and installing application updates."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+from packaging import version as packaging_version
+
+from .version import APP_VERSION
+
+LOGGER = logging.getLogger(__name__)
+
+REPO_SLUG: Final[str] = os.getenv("VLIER_UPDATE_REPO", "ramonankersmit/vlier-planner")
+API_LATEST: Final[str] = f"https://api.github.com/repos/{REPO_SLUG}/releases/latest"
+APP_NAME: Final[str] = os.getenv("VLIER_UPDATE_APP_NAME", "VlierPlanner")
+_CACHE_TTL_SECONDS: Final[int] = 15 * 60
+
+
+class UpdateError(RuntimeError):
+    """Raised when checking or installing an update fails."""
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateInfo:
+    """Information about an available update."""
+
+    current_version: str
+    latest_version: str
+    asset_name: str
+    download_url: str
+    release_notes: str | None
+    sha256: str | None
+
+
+_CACHE: tuple[float, UpdateInfo | None] | None = None
+
+
+def _user_agent() -> str:
+    return f"{APP_NAME}/update-check"
+
+
+def _http_get_json(url: str) -> Any:
+    request = Request(url, headers={"User-Agent": _user_agent()})
+    with urlopen(request, timeout=20) as response:  # noqa: S310 - controlled URL
+        data = response.read()
+    return json.loads(data.decode("utf-8"))
+
+
+def _download(url: str, destination: Path) -> Path:
+    request = Request(url, headers={"User-Agent": _user_agent()})
+    with urlopen(request, timeout=60) as response, destination.open("wb") as file:  # noqa: S310
+        shutil.copyfileobj(response, file)
+    return destination
+
+
+def _sha256sum(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _parse_version(value: str) -> packaging_version.Version | None:
+    try:
+        return packaging_version.Version(value)
+    except packaging_version.InvalidVersion:
+        LOGGER.warning("Ongeldige versiestring: %s", value)
+        return None
+
+
+def _extract_sha256(notes: str | None) -> str | None:
+    if not notes:
+        return None
+    for line in notes.splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        if key.strip().upper() == "SHA256":
+            checksum = value.strip()
+            if checksum:
+                return checksum
+    return None
+
+
+def _pick_windows_asset(assets: list[dict[str, Any]]) -> dict[str, Any] | None:
+    candidates: list[dict[str, Any]] = []
+    for asset in assets:
+        name = str(asset.get("name", ""))
+        if not name.lower().endswith((".exe", ".msi")):
+            continue
+        if "win" not in name.lower() and "setup" not in name.lower():
+            continue
+        candidates.append(asset)
+
+    if not candidates:
+        return None
+
+    for candidate in candidates:
+        name = str(candidate.get("name", ""))
+        if "setup" in name.lower() or "installer" in name.lower():
+            return candidate
+
+    return candidates[0]
+
+
+def _resolve_updates_dir() -> Path:
+    if sys.platform == "win32":
+        base = os.getenv("LOCALAPPDATA") or (Path.home() / "AppData" / "Local")
+    elif sys.platform == "darwin":
+        base = Path.home() / "Library" / "Application Support"
+    else:
+        base = os.getenv("XDG_DATA_HOME") or (Path.home() / ".local" / "share")
+
+    updates_dir = Path(base) / APP_NAME / "updates"
+    updates_dir.mkdir(parents=True, exist_ok=True)
+    return updates_dir
+
+
+def _fetch_update_info() -> UpdateInfo | None:
+    try:
+        payload = _http_get_json(API_LATEST)
+    except URLError as exc:  # pragma: no cover - netwerkafhankelijk
+        raise UpdateError(f"Kon release-informatie niet ophalen: {exc}") from exc
+    except TimeoutError as exc:  # pragma: no cover - netwerkafhankelijk
+        raise UpdateError("Timeout bij ophalen van release-informatie") from exc
+    except Exception as exc:  # pragma: no cover - defensief
+        raise UpdateError(f"Onbekende fout tijdens update-check: {exc}") from exc
+
+    latest_tag = str(payload.get("tag_name", "")).strip()
+    if not latest_tag:
+        return None
+    latest_version_str = latest_tag.lstrip("v")
+
+    asset = _pick_windows_asset(payload.get("assets", []) or [])
+    if not asset:
+        LOGGER.info("Geen Windows release asset gevonden in release %s", latest_tag)
+        return None
+
+    latest_version = _parse_version(latest_version_str)
+    current_version = _parse_version(APP_VERSION)
+
+    if latest_version is None or current_version is None:
+        return None
+
+    if latest_version <= current_version:
+        return None
+
+    notes = payload.get("body")
+    checksum = _extract_sha256(notes)
+
+    download_url = str(asset.get("browser_download_url"))
+    if not download_url:
+        LOGGER.info("Release asset mist download URL")
+        return None
+
+    asset_name = str(asset.get("name", "")) or f"update-{latest_version_str}.exe"
+
+    return UpdateInfo(
+        current_version=APP_VERSION,
+        latest_version=latest_version_str,
+        asset_name=asset_name,
+        download_url=download_url,
+        release_notes=notes,
+        sha256=checksum,
+    )
+
+
+def check_for_update(force: bool = False) -> UpdateInfo | None:
+    """Return information about an available update, if any."""
+
+    global _CACHE
+
+    if not force and _CACHE is not None:
+        timestamp, cached = _CACHE
+        if time.time() - timestamp < _CACHE_TTL_SECONDS:
+            return cached
+
+    info = _fetch_update_info()
+    _CACHE = (time.time(), info)
+    return info
+
+
+def _should_use_silent_install() -> bool:
+    return os.getenv("VLIER_UPDATE_SILENT", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def install_update(info: UpdateInfo, *, silent: bool | None = None) -> Path:
+    """Download the installer for ``info`` and start the installation."""
+
+    if sys.platform != "win32":
+        raise UpdateError("Automatische updates worden alleen op Windows ondersteund")
+
+    updates_dir = _resolve_updates_dir()
+    destination = updates_dir / info.asset_name
+
+    try:
+        _download(info.download_url, destination)
+    except URLError as exc:  # pragma: no cover - netwerkafhankelijk
+        raise UpdateError(f"Download van update mislukt: {exc}") from exc
+    except TimeoutError as exc:  # pragma: no cover - netwerkafhankelijk
+        raise UpdateError("Timeout tijdens download van update") from exc
+    except Exception as exc:  # pragma: no cover - defensief
+        raise UpdateError(f"Onbekende fout tijdens download: {exc}") from exc
+
+    if info.sha256:
+        actual = _sha256sum(destination)
+        if actual.lower() != info.sha256.lower():
+            try:
+                destination.unlink(missing_ok=True)
+            except Exception:  # pragma: no cover - best effort
+                LOGGER.warning("Kon corrupt updatebestand niet verwijderen: %s", destination)
+            raise UpdateError("Controle van de bestandshandtekening is mislukt")
+
+    flags: list[str] = []
+    use_silent = _should_use_silent_install() if silent is None else silent
+    if use_silent:
+        flags.extend(["/VERYSILENT", "/NORESTART"])
+
+    try:
+        subprocess.Popen([str(destination), *flags], shell=False, close_fds=True)  # noqa: S603,S607
+    except Exception as exc:  # pragma: no cover - afhankelijk van platform
+        raise UpdateError(f"Kon installer niet starten: {exc}") from exc
+
+    def _terminate() -> None:
+        LOGGER.info("Applicatie wordt afgesloten voor update")
+        os._exit(0)
+
+    threading.Timer(2.0, _terminate).start()
+    return destination
+
+
+__all__ = ["UpdateError", "UpdateInfo", "check_for_update", "install_update"]
+

--- a/backend/updater.py
+++ b/backend/updater.py
@@ -19,7 +19,10 @@ from urllib.request import Request, urlopen
 
 from packaging import version as packaging_version
 
-from .version import APP_VERSION
+try:  # pragma: no cover - allow running as module or package
+    from .version import APP_VERSION
+except ImportError:  # pragma: no cover - fallback when executed as a script
+    from version import APP_VERSION  # type: ignore
 
 LOGGER = logging.getLogger(__name__)
 

--- a/backend/version.py
+++ b/backend/version.py
@@ -1,0 +1,26 @@
+"""Application version information used throughout the backend."""
+
+from __future__ import annotations
+
+import os
+
+
+DEFAULT_VERSION = "0.0.0-dev"
+
+
+def _resolve_version() -> str:
+    """Return the version string for the running application."""
+
+    env_value = os.getenv("VLIER_APP_VERSION")
+    if env_value:
+        cleaned = env_value.strip()
+        if cleaned:
+            return cleaned
+
+    return DEFAULT_VERSION
+
+
+APP_VERSION = _resolve_version()
+
+__all__ = ["APP_VERSION"]
+

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,14 +42,17 @@ function useStoreHydration() {
   return hydrated;
 }
 
-function AppContent() {
+type AppContentProps = {
+  hasHydratedStore: boolean;
+};
+
+function AppContent({ hasHydratedStore }: AppContentProps) {
   const hasDocs = useAppStore((state) => state.docs.length > 0);
   const docsInitialized = useAppStore((state) => state.docsInitialized);
   const lastVisitedRoute = useAppStore((state) => state.lastVisitedRoute);
   const setLastVisitedRoute = useAppStore((state) => state.setLastVisitedRoute);
   const navigate = useNavigate();
   const location = useLocation();
-  const hasHydratedStore = useStoreHydration();
   const [initialRouteHandled, setInitialRouteHandled] = React.useState(false);
   const previousHasDocsRef = React.useRef<boolean | null>(null);
 
@@ -132,6 +135,89 @@ function AppContent() {
 }
 
 export default function App() {
+  const hasHydratedStore = useStoreHydration();
+  const enableAutoUpdate = useAppStore((state) => state.enableAutoUpdate);
+  const [shouldCheckUpdate, setShouldCheckUpdate] = React.useState(true);
+  const lastPromptedVersionRef = React.useRef<string | null>(null);
+  const prevAutoUpdateRef = React.useRef(enableAutoUpdate);
+
+  React.useEffect(() => {
+    if (!hasHydratedStore) {
+      return;
+    }
+    if (prevAutoUpdateRef.current === enableAutoUpdate) {
+      return;
+    }
+    if (enableAutoUpdate) {
+      setShouldCheckUpdate(true);
+    }
+    prevAutoUpdateRef.current = enableAutoUpdate;
+  }, [enableAutoUpdate, hasHydratedStore]);
+
+  React.useEffect(() => {
+    if (!hasHydratedStore || !enableAutoUpdate || !shouldCheckUpdate) {
+      return;
+    }
+
+    let cancelled = false;
+    setShouldCheckUpdate(false);
+
+    (async () => {
+      try {
+        const api = await import("./lib/api");
+        const result = await api.apiCheckForUpdate();
+        if (cancelled) {
+          return;
+        }
+        if (!result.updateAvailable || !result.latestVersion) {
+          return;
+        }
+        if (lastPromptedVersionRef.current === result.latestVersion) {
+          return;
+        }
+        lastPromptedVersionRef.current = result.latestVersion;
+
+        const rawNotes = (result.notes ?? "").trim();
+        const maxLength = 600;
+        const snippet =
+          rawNotes && rawNotes.length > maxLength
+            ? `${rawNotes.slice(0, maxLength - 3)}...`
+            : rawNotes;
+
+        let message = `Er is een nieuwe versie beschikbaar (v${result.latestVersion}).`;
+        message += `\nHuidige versie: v${result.currentVersion}.`;
+        if (snippet) {
+          message += `\n\nWijzigingen:\n${snippet}`;
+        }
+        message += "\n\nWil je de update nu installeren?";
+
+        const confirmed = window.confirm(message);
+        if (!confirmed) {
+          return;
+        }
+
+        try {
+          await api.apiInstallUpdate(result.latestVersion);
+          window.alert(
+            "De installer is gestart. Sluit Vlier Planner af wanneer daarom wordt gevraagd om de update te voltooien."
+          );
+        } catch (error) {
+          console.error("Kon update niet starten:", error);
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          window.alert(`Update kon niet worden gestart: ${errorMessage}`);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          console.warn("Automatische update-check mislukt:", error);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enableAutoUpdate, hasHydratedStore, shouldCheckUpdate]);
+
   // Hydrate globale docs-store vanaf de backend zodra de app mount
   useEffect(() => {
     hydrateDocsFromApi();
@@ -142,7 +228,7 @@ export default function App() {
       <DocumentPreviewProvider>
         <OnboardingTourProvider>
           <AppShell>
-            <AppContent />
+            <AppContent hasHydratedStore={hasHydratedStore} />
           </AppShell>
         </OnboardingTourProvider>
       </DocumentPreviewProvider>

--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -106,6 +106,8 @@ type State = {
   setEnableHomeworkEditing: (value: boolean) => void;
   enableCustomHomework: boolean;
   setEnableCustomHomework: (value: boolean) => void;
+  enableAutoUpdate: boolean;
+  setEnableAutoUpdate: (value: boolean) => void;
 
   // ==== afvinkstatus gedeeld ====
   doneMap: Record<string, boolean>;
@@ -402,6 +404,7 @@ const createInitialState = (): Pick<
   | "surfaceOpacity"
   | "enableHomeworkEditing"
   | "enableCustomHomework"
+  | "enableAutoUpdate"
   | "doneMap"
   | "weekIdxWO"
   | "niveauWO"
@@ -425,6 +428,7 @@ const createInitialState = (): Pick<
   surfaceOpacity: 100,
   enableHomeworkEditing: true,
   enableCustomHomework: true,
+  enableAutoUpdate: true,
   doneMap: {},
   weekIdxWO: 0,
   niveauWO: "ALLE",
@@ -724,6 +728,8 @@ export const useAppStore = create<State>()(
         set(() => ({ enableHomeworkEditing: !!value })),
       setEnableCustomHomework: (value) =>
         set(() => ({ enableCustomHomework: !!value })),
+      setEnableAutoUpdate: (value) =>
+        set(() => ({ enableAutoUpdate: !!value })),
 
       // ----------------------------
       // done-map
@@ -803,6 +809,7 @@ export const useAppStore = create<State>()(
         surfaceOpacity: state.surfaceOpacity,
         enableHomeworkEditing: state.enableHomeworkEditing,
         enableCustomHomework: state.enableCustomHomework,
+        enableAutoUpdate: state.enableAutoUpdate,
         doneMap: state.doneMap,
         weekIdxWO: state.weekIdxWO,
         niveauWO: state.niveauWO,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -109,3 +109,32 @@ export async function apiGetDocPreview(fileId: string): Promise<DocPreview> {
   }
   return r.json();
 }
+
+export type UpdateCheckResponse = {
+  updateAvailable: boolean;
+  currentVersion: string;
+  latestVersion?: string;
+  assetName?: string;
+  notes?: string | null;
+  checksum?: string | null;
+};
+
+export async function apiCheckForUpdate(): Promise<UpdateCheckResponse> {
+  const response = await fetch(`${BASE}/api/system/update`);
+  if (!response.ok) {
+    throw new Error(`update_check failed: ${response.status}`);
+  }
+  return response.json();
+}
+
+export async function apiInstallUpdate(version: string): Promise<void> {
+  const response = await fetch(`${BASE}/api/system/update`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ version }),
+  });
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`update_install failed: ${response.status} – ${message}`);
+  }
+}

--- a/frontend/src/lib/updatePrompt.ts
+++ b/frontend/src/lib/updatePrompt.ts
@@ -1,0 +1,74 @@
+import { apiCheckForUpdate, apiInstallUpdate, type UpdateCheckResponse } from "./api";
+
+const MAX_NOTES_LENGTH = 600;
+
+export async function promptUpdateInstallation(
+  result: UpdateCheckResponse,
+  options?: { suppressSuccessAlert?: boolean }
+): Promise<boolean> {
+  if (!result.updateAvailable || !result.latestVersion) {
+    return false;
+  }
+
+  const rawNotes = (result.notes ?? "").trim();
+  const snippet =
+    rawNotes && rawNotes.length > MAX_NOTES_LENGTH
+      ? `${rawNotes.slice(0, MAX_NOTES_LENGTH - 3)}...`
+      : rawNotes;
+
+  let message = `Er is een nieuwe versie beschikbaar (v${result.latestVersion}).`;
+  message += `\nHuidige versie: v${result.currentVersion}.`;
+  if (snippet) {
+    message += `\n\nWijzigingen:\n${snippet}`;
+  }
+  message += "\n\nWil je de update nu installeren?";
+
+  const confirmed = window.confirm(message);
+  if (!confirmed) {
+    return false;
+  }
+
+  try {
+    await apiInstallUpdate(result.latestVersion);
+    if (!options?.suppressSuccessAlert) {
+      window.alert(
+        "De installer is gestart. Sluit Vlier Planner af wanneer daarom wordt gevraagd om de update te voltooien."
+      );
+    }
+    return true;
+  } catch (error) {
+    console.error("Kon update niet starten:", error);
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    window.alert(`Update kon niet worden gestart: ${errorMessage}`);
+    return false;
+  }
+}
+
+export async function checkAndPromptForUpdate(
+  options?: { showNoUpdateMessage?: boolean }
+): Promise<{
+  result: UpdateCheckResponse;
+  updateStarted: boolean;
+}> {
+  const result = await apiCheckForUpdate();
+
+  if (!result.updateAvailable || !result.latestVersion) {
+    if (options?.showNoUpdateMessage) {
+      window.alert(`Je gebruikt momenteel de nieuwste versie (v${result.currentVersion}).`);
+    }
+    return { result, updateStarted: false };
+  }
+
+  const updateStarted = await promptUpdateInstallation(result, {
+    suppressSuccessAlert: options?.showNoUpdateMessage,
+  });
+
+  if (options?.showNoUpdateMessage && updateStarted) {
+    window.alert(
+      `De update naar v${result.latestVersion} is gestart. Sluit Vlier Planner af wanneer daarom wordt gevraagd.`
+    );
+  }
+
+  return { result, updateStarted };
+}
+

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -21,6 +21,8 @@ export default function Settings() {
     setEnableHomeworkEditing,
     enableCustomHomework,
     setEnableCustomHomework,
+    enableAutoUpdate,
+    setEnableAutoUpdate,
     resetAppState,
   } = useAppStore();
   const docs = useAppStore((s) => s.docs) ?? [];
@@ -234,6 +236,20 @@ export default function Settings() {
               <div className="text-sm font-medium theme-text">Eigen taak toevoegen</div>
               <div className="text-xs leading-snug theme-muted">
                 Toon de knop om zelf extra taakregels toe te voegen aan een week.
+              </div>
+            </div>
+          </label>
+          <label className="flex items-start gap-3 rounded-md border theme-border theme-soft p-3">
+            <input
+              type="checkbox"
+              checked={enableAutoUpdate}
+              onChange={(event) => setEnableAutoUpdate(event.target.checked)}
+              className="mt-1"
+            />
+            <div className="flex-1">
+              <div className="text-sm font-medium theme-text">Automatisch op updates controleren</div>
+              <div className="text-xs leading-snug theme-muted">
+                Vraag bij het opstarten om een nieuwe versie te installeren wanneer die beschikbaar is.
               </div>
             </div>
           </label>


### PR DESCRIPTION
## Summary
- implement a backend updater module that checks GitHub releases, downloads installers, and exposes update endpoints with version metadata
- extend the frontend store and API helpers with a persisted auto-update toggle and calls for checking or installing updates
- prompt users about new versions on startup and surface a settings toggle to enable or disable automatic update checks

## Testing
- pytest
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d03eb9896083228d5dc702261cd519