### PR TITLE
Fix createInitialState arrow function syntax

### DIFF
--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -525,36 +525,37 @@ const createInitialState = (): Pick<
   | "matrixNiveau"
   | "matrixLeerjaar"
   | "lastVisitedRoute"
-> => (
+> => {
   const { presets, activeThemeId, theme, backgroundImage, surfaceOpacity } =
     resolveActiveThemeState(createThemePresets(), "default");
   return {
-  docs: [],
-  docsInitialized: false,
-  docRows: {},
-  weekData: { weeks: [], byWeek: {} },
-  customHomework: {},
-  homeworkAdjustments: {},
-  mijnVakken: [],
-  huiswerkWeergave: "perOpdracht",
-  themePresets: presets,
-  activeThemeId,
-  theme,
-  backgroundImage,
-  surfaceOpacity,
-  enableHomeworkEditing: true,
-  enableCustomHomework: true,
-  enableAutoUpdate: true,
-  doneMap: {},
-  weekIdxWO: 0,
-  niveauWO: "ALLE",
-  leerjaarWO: "ALLE",
-  matrixStartIdx: -1,
-  matrixCount: 3,
-  matrixNiveau: "ALLE",
-  matrixLeerjaar: "ALLE",
-  lastVisitedRoute: "/",
-});
+    docs: [],
+    docsInitialized: false,
+    docRows: {},
+    weekData: { weeks: [], byWeek: {} },
+    customHomework: {},
+    homeworkAdjustments: {},
+    mijnVakken: [],
+    huiswerkWeergave: "perOpdracht",
+    themePresets: presets,
+    activeThemeId,
+    theme,
+    backgroundImage,
+    surfaceOpacity,
+    enableHomeworkEditing: true,
+    enableCustomHomework: true,
+    enableAutoUpdate: true,
+    doneMap: {},
+    weekIdxWO: 0,
+    niveauWO: "ALLE",
+    leerjaarWO: "ALLE",
+    matrixStartIdx: -1,
+    matrixCount: 3,
+    matrixNiveau: "ALLE",
+    matrixLeerjaar: "ALLE",
+    lastVisitedRoute: "/",
+  };
+};
 
 export const useAppStore = create<State>()(
   persist(


### PR DESCRIPTION
## Summary
- replace the invalid parenthesized arrow function in `createInitialState` with a block body and explicit return
- ensure initial state object is returned correctly for the store initialization

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d05b3f0dec83229369227cdcd2e226