### PR TITLE
Ensure matrix overview opens on current week and simplify uploads nav

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -61,7 +61,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
       { to: "/", label: "Weekoverzicht" },
       { to: "/matrix", label: "Matrix overzicht" },
       { to: "/deadlines", label: "Belangrijke events" },
-      { to: "/uploads", label: "Uploads", icon: UploadCloud },
+      { to: "/uploads", label: "Uploads", icon: UploadCloud, hideLabel: true },
       { to: "/uitleg", label: "Uitleg", icon: Info, hideLabel: true },
       { to: "/settings", label: "Settings", icon: SettingsIcon, hideLabel: true },
     ],

--- a/frontend/src/pages/Matrix.tsx
+++ b/frontend/src/pages/Matrix.tsx
@@ -709,7 +709,7 @@ export default function Matrix() {
     setStartIdx(Math.min(maxStart, clampedStart + 1));
   };
   const goThisWeek = React.useCallback(
-    (align: "center" | "start" = "center") => {
+    (align: "center" | "start" = "start") => {
       if (disableWeekControls) return;
       const targetWeekId = allWeeks[currentWeekIdx]?.id;
       const start = computeWindowStartForWeek(allWeeks, count, targetWeekId, {


### PR DESCRIPTION
## Summary
- default the matrix overview to align the current week at the start of the viewport
- hide the label on the uploads navigation button so only the icon remains visible

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d1adc9b9a48322aaedd9b28fcb4720