### PR TITLE
Include VERSION.ini in PyInstaller build

### DIFF
--- a/VlierPlanner.spec
+++ b/VlierPlanner.spec
@@ -96,7 +96,10 @@ VSVersionInfo(
 APP_VERSION = _load_version()
 VERSION_FILE = _write_version_file(APP_VERSION)
 
-datas = [('backend/static/dist', 'backend/static/dist')]
+datas = [
+    ('VERSION.ini', '.'),
+    ('backend/static/dist', 'backend/static/dist'),
+]
 binaries = []
 hiddenimports = []
 tmp_ret = collect_all('vlier_parser')


### PR DESCRIPTION
## Summary
- bundle VERSION.ini with the frozen application so the backend can resolve the packaged version number

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2fb8367ec8322970158306379a21e