### PR TITLE
Add school vacation download flow

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -11,8 +11,9 @@ from html import escape
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import quote
 
-from fastapi import Body, FastAPI, File, HTTPException, UploadFile
-from pydantic import BaseModel
+import httpx
+from fastapi import Body, FastAPI, File, HTTPException, UploadFile, Query
+from pydantic import AliasChoices, BaseModel, Field, ConfigDict
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
@@ -68,12 +69,17 @@ except ImportError:  # pragma: no cover
         write_pending_parse,
     )
 
-try:  
+try:
     from .version import APP_VERSION
     from . import updater
 except ImportError:  # pragma: no cover
     from version import APP_VERSION  # type: ignore
     import updater  # type: ignore
+
+try:
+    from .school_vacations import fetch_school_vacations
+except ImportError:  # pragma: no cover
+    from school_vacations import fetch_school_vacations  # type: ignore
 
 app = FastAPI(title="Vlier Planner API")
 
@@ -306,6 +312,45 @@ class UpdateRequest(BaseModel):
     silent: bool | None = None
 
 
+class SchoolVacationItemModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    name: str
+    region: str
+    startDate: str = Field(
+        ...,
+        validation_alias=AliasChoices("startDate", "start_date"),
+        serialization_alias="startDate",
+    )
+    endDate: str = Field(
+        ...,
+        validation_alias=AliasChoices("endDate", "end_date"),
+        serialization_alias="endDate",
+    )
+    schoolYear: str = Field(
+        ...,
+        validation_alias=AliasChoices("schoolYear", "school_year"),
+        serialization_alias="schoolYear",
+    )
+    source: str
+    label: str
+    rawText: str = Field(
+        ...,
+        validation_alias=AliasChoices("rawText", "raw_text"),
+        serialization_alias="rawText",
+    )
+    notes: Optional[str] = None
+
+
+class SchoolVacationResponse(BaseModel):
+    schoolYear: str
+    source: str
+    retrievedAt: str
+    title: Optional[str] = None
+    vacations: List[SchoolVacationItemModel]
+
+
 def _truncate_notes(text: str | None, limit: int = 2000) -> str | None:
     if not text:
         return None
@@ -366,6 +411,34 @@ def api_install_update(payload: UpdateRequest) -> dict[str, Any]:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     return {"status": "started", "installerPath": str(installer_path)}
+
+
+@app.get("/api/school-vacations", response_model=SchoolVacationResponse)
+async def api_get_school_vacations(
+    school_year: str = Query(..., alias="schoolYear"),
+) -> dict[str, Any]:
+    try:
+        data = await fetch_school_vacations(school_year)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except httpx.HTTPError as exc:
+        logger.warning("Schoolvakanties downloaden mislukt: %s", exc)
+        raise HTTPException(status_code=502, detail="Download van schoolvakanties mislukt") from exc
+
+    vacations_raw = data.get("vacations", [])
+    items = [SchoolVacationItemModel.model_validate(entry) for entry in vacations_raw]
+    items.sort(key=lambda item: (item.startDate, item.endDate, item.region))
+
+    response = SchoolVacationResponse(
+        schoolYear=data.get("schoolYear", school_year),
+        source=data.get("source"),
+        retrievedAt=data.get("retrievedAt"),
+        title=data.get("title"),
+        vacations=items,
+    )
+
+    return response.model_dump()
+
 
 # -----------------------------
 # Endpoints

--- a/backend/school_vacations.py
+++ b/backend/school_vacations.py
@@ -1,0 +1,265 @@
+"""Utilities voor het ophalen en parsen van schoolvakanties van rijksoverheid.nl."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from typing import Any, Awaitable, Callable, List, Optional
+
+import httpx
+from lxml import html
+
+MONTHS = {
+    "januari": 1,
+    "februari": 2,
+    "maart": 3,
+    "april": 4,
+    "mei": 5,
+    "juni": 6,
+    "juli": 7,
+    "augustus": 8,
+    "september": 9,
+    "oktober": 10,
+    "november": 11,
+    "december": 12,
+}
+
+SCHOOL_YEAR_RE = re.compile(r"^(?P<start>\d{4})-(?P<end>\d{4})$")
+
+RANGE_PATTERN = re.compile(
+    r"(\d{1,2}\s+[a-zäëïöüé]+(?:\s+\d{4})?)\s*(?:t/m|tm|tot en met|\-|–)\s*(\d{1,2}\s+[a-zäëïöüé]+(?:\s+\d{4})?)",
+    re.IGNORECASE,
+)
+
+DATE_PATTERN = re.compile(r"(\d{1,2})\s+([a-zäëïöüé]+)(?:\s+(\d{4}))?", re.IGNORECASE)
+
+
+@dataclass
+class SchoolVacation:
+    """Gestructureerde informatie over één vakantieperiode."""
+
+    id: str
+    name: str
+    region: str
+    start_date: str
+    end_date: str
+    school_year: str
+    source: str
+    label: str
+    raw_text: str
+    notes: Optional[str] = None
+
+    def to_api(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "region": self.region,
+            "startDate": self.start_date,
+            "endDate": self.end_date,
+            "schoolYear": self.school_year,
+            "source": self.source,
+            "label": self.label,
+            "rawText": self.raw_text,
+            "notes": self.notes,
+        }
+
+
+def _normalize_school_year(school_year: str) -> tuple[str, int, int]:
+    match = SCHOOL_YEAR_RE.match(school_year.strip())
+    if not match:
+        raise ValueError("Ongeldig schooljaarformaat. Verwacht JJJJ-JJJJ")
+    start_year = int(match.group("start"))
+    end_year = int(match.group("end"))
+    if end_year - start_year != 1:
+        raise ValueError("Schooljaar moet twee opeenvolgende jaren bevatten")
+    return school_year, start_year, end_year
+
+
+def _build_source_url(school_year: str) -> str:
+    normalized, _, _ = _normalize_school_year(school_year)
+    return (
+        "https://www.rijksoverheid.nl/onderwerpen/schoolvakanties/"
+        "overzicht-schoolvakanties-per-schooljaar/"
+        f"overzicht-schoolvakanties-{normalized}"
+    )
+
+
+def _slugify(value: str) -> str:
+    value = value.strip().lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    return value.strip("-") or "vakantie"
+
+
+def _clean_text(text: str) -> str:
+    cleaned = re.sub(r"\s+", " ", text)
+    cleaned = cleaned.replace("\xa0", " ").strip()
+    return cleaned
+
+
+def _parse_single_date(text: str, start_year: int, end_year: int) -> date:
+    match = DATE_PATTERN.search(text.strip())
+    if not match:
+        raise ValueError(f"Kan datum niet parsen uit '{text}'")
+    day_str, month_name, year_str = match.groups()
+    day = int(re.sub(r"\D", "", day_str))
+    month_key = month_name.lower()
+    if month_key not in MONTHS:
+        raise ValueError(f"Onbekende maandnaam '{month_name}' in '{text}'")
+    month = MONTHS[month_key]
+    if year_str:
+        year = int(year_str)
+    else:
+        year = start_year if month >= 7 else end_year
+    return date(year, month, day)
+
+
+def _extract_ranges(content: str, start_year: int, end_year: int) -> List[tuple[date, date, str]]:
+    cleaned = _clean_text(content)
+    ranges: List[tuple[date, date, str]] = []
+    for match in RANGE_PATTERN.finditer(cleaned):
+        raw = match.group(0)
+        start_txt, end_txt = match.groups()
+        try:
+            start_dt = _parse_single_date(start_txt, start_year, end_year)
+            end_dt = _parse_single_date(end_txt, start_year, end_year)
+        except ValueError:
+            continue
+        if end_dt < start_dt:
+            # Als de parsing een verkeerd jaar oplevert, forceer de volgorde
+            start_dt, end_dt = end_dt, start_dt
+        ranges.append((start_dt, end_dt, raw))
+
+    if not ranges:
+        single_match = DATE_PATTERN.search(cleaned)
+        if single_match:
+            try:
+                single_date = _parse_single_date(single_match.group(0), start_year, end_year)
+                ranges.append((single_date, single_date, single_match.group(0)))
+            except ValueError:
+                pass
+
+    return ranges
+
+
+def _parse_cell(
+    name: str,
+    region: str,
+    cell: html.HtmlElement,
+    start_year: int,
+    end_year: int,
+    school_year: str,
+    source_url: str,
+) -> List[SchoolVacation]:
+    raw_text = " ".join(t.strip() for t in cell.itertext())
+    cleaned = _clean_text(raw_text)
+    if not cleaned or cleaned in {"-", "—", "n.v.t."}:
+        return []
+
+    ranges = _extract_ranges(cleaned, start_year, end_year)
+    if not ranges:
+        return []
+
+    notes_match = re.sub(RANGE_PATTERN, "", cleaned).strip()
+    notes = notes_match if notes_match else None
+    vacations: List[SchoolVacation] = []
+    for start_dt, end_dt, label in ranges:
+        vac_id = f"{_slugify(name)}-{_slugify(region)}-{start_dt.isoformat()}-{end_dt.isoformat()}"
+        vacations.append(
+            SchoolVacation(
+                id=vac_id,
+                name=name,
+                region=region,
+                start_date=start_dt.isoformat(),
+                end_date=end_dt.isoformat(),
+                school_year=school_year,
+                source=source_url,
+                label=_clean_text(label),
+                raw_text=cleaned,
+                notes=notes,
+            )
+        )
+    return vacations
+
+
+def parse_school_vacations(html_content: str, school_year: str, source_url: str) -> List[SchoolVacation]:
+    _, start_year, end_year = _normalize_school_year(school_year)
+    doc = html.fromstring(html_content)
+
+    tables = doc.xpath(
+        "//table[.//th[contains(translate(normalize-space(.), 'VAKANTIE', 'vakantie'), 'vakantie')]]"
+    )
+    if not tables:
+        raise ValueError("Kon geen vakantiestabel vinden in de bron")
+
+    table = tables[0]
+    header_cells = table.xpath(".//thead//tr[1]/th")
+    headers = [_clean_text("".join(cell.itertext())) for cell in header_cells]
+    if not headers:
+        raise ValueError("De tabel bevat geen kolomkoppen")
+
+    regions = headers[1:] if len(headers) > 1 else []
+
+    vacations: List[SchoolVacation] = []
+
+    for row in table.xpath(".//tbody/tr"):
+        cells = row.xpath("./th|./td")
+        if len(cells) <= 1:
+            continue
+        name = _clean_text("".join(cells[0].itertext()))
+        if not name:
+            continue
+        for idx, cell in enumerate(cells[1:], start=1):
+            region = regions[idx - 1] if idx - 1 < len(regions) else f"Kolom {idx}"
+            region_clean = region.replace("Regio", "").strip().capitalize() or region
+            vacations.extend(
+                _parse_cell(name, region_clean, cell, start_year, end_year, school_year, source_url)
+            )
+
+    return vacations
+
+
+async def _default_http_get(url: str) -> str:
+    async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+        response = await client.get(url, headers={"User-Agent": "VlierPlanner/1.0"})
+        response.raise_for_status()
+        return response.text
+
+
+async def fetch_school_vacations(
+    school_year: str,
+    *,
+    http_get: Optional[Callable[[str], Awaitable[str]]] = None,
+) -> dict:
+    """Download en parse schoolvakanties voor het opgegeven schooljaar."""
+
+    url = _build_source_url(school_year)
+
+    getter: Callable[[str], Awaitable[str]]
+    if http_get is None:
+        getter = _default_http_get  # type: ignore[assignment]
+    else:
+        getter = http_get
+
+    html_content = await getter(url)
+    vacations = parse_school_vacations(html_content, school_year, url)
+
+    doc = html.fromstring(html_content)
+    title = doc.xpath("string(//h1)") or doc.xpath("string(//title)") or ""
+    normalized_title = _clean_text(title)
+
+    return {
+        "schoolYear": school_year,
+        "source": url,
+        "retrievedAt": datetime.now(timezone.utc).isoformat(),
+        "title": normalized_title or None,
+        "vacations": [vac.to_api() for vac in vacations],
+    }
+
+
+__all__ = [
+    "SchoolVacation",
+    "fetch_school_vacations",
+    "parse_school_vacations",
+]
+

--- a/backend/school_vacations.py
+++ b/backend/school_vacations.py
@@ -97,7 +97,22 @@ def _clean_text(text: str) -> str:
     return cleaned
 
 
-def _parse_single_date(text: str, start_year: int, end_year: int) -> date:
+def _extract_year_hint(text: str) -> Optional[int]:
+    match = DATE_PATTERN.search(text.strip())
+    if not match:
+        return None
+    year_str = match.group(3)
+    if not year_str:
+        return None
+    try:
+        return int(year_str)
+    except ValueError:
+        return None
+
+
+def _parse_single_date(
+    text: str, start_year: int, end_year: int, preferred_year: Optional[int] = None
+) -> date:
     match = DATE_PATTERN.search(text.strip())
     if not match:
         raise ValueError(f"Kan datum niet parsen uit '{text}'")
@@ -110,12 +125,15 @@ def _parse_single_date(text: str, start_year: int, end_year: int) -> date:
     if year_str:
         year = int(year_str)
     else:
-        # Vakanties zonder jaartal vallen in de regel in het lopende schooljaar.
-        # Maanden september t/m december horen bij het startjaar; alle eerdere
-        # maanden (januari t/m augustus) bij het eindjaar. Hierdoor komen
-        # zomervakanties in juli/augustus automatisch in het juiste kalenderjaar
-        # terecht.
-        year = start_year if month >= 9 else end_year
+        if preferred_year is not None:
+            year = preferred_year
+        else:
+            # Vakanties zonder jaartal vallen in de regel in het lopende schooljaar.
+            # Maanden september t/m december horen bij het startjaar; alle eerdere
+            # maanden (januari t/m augustus) bij het eindjaar. Hierdoor komen
+            # zomervakanties in juli/augustus automatisch in het juiste kalenderjaar
+            # terecht.
+            year = start_year if month >= 9 else end_year
     return date(year, month, day)
 
 
@@ -126,8 +144,14 @@ def _extract_ranges(content: str, start_year: int, end_year: int) -> List[tuple[
         raw = match.group(0)
         start_txt, end_txt = match.groups()
         try:
-            start_dt = _parse_single_date(start_txt, start_year, end_year)
-            end_dt = _parse_single_date(end_txt, start_year, end_year)
+            start_hint = _extract_year_hint(start_txt)
+            end_hint = _extract_year_hint(end_txt)
+            start_dt = _parse_single_date(
+                start_txt, start_year, end_year, preferred_year=end_hint
+            )
+            end_dt = _parse_single_date(
+                end_txt, start_year, end_year, preferred_year=start_hint
+            )
         except ValueError:
             continue
         if end_dt < start_dt:

--- a/backend/school_vacations.py
+++ b/backend/school_vacations.py
@@ -110,7 +110,12 @@ def _parse_single_date(text: str, start_year: int, end_year: int) -> date:
     if year_str:
         year = int(year_str)
     else:
-        year = start_year if month >= 7 else end_year
+        # Vakanties zonder jaartal vallen in de regel in het lopende schooljaar.
+        # Maanden september t/m december horen bij het startjaar; alle eerdere
+        # maanden (januari t/m augustus) bij het eindjaar. Hierdoor komen
+        # zomervakanties in juli/augustus automatisch in het juiste kalenderjaar
+        # terecht.
+        year = start_year if month >= 9 else end_year
     return date(year, month, day)
 
 

--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -235,6 +235,7 @@ type State = {
   addSchoolVacations: (entries: SchoolVacation[]) => void;
   updateSchoolVacation: (id: string, update: Partial<SchoolVacation>) => void;
   removeSchoolVacation: (id: string) => void;
+  clearSchoolVacations: () => void;
   setSchoolVacationActive: (id: string, active: boolean) => void;
   customHomework: Record<string, Record<string, CustomHomeworkEntry[]>>;
   addCustomHomework: (weekId: string, vak: string, text: string) => void;
@@ -1167,6 +1168,15 @@ export const useAppStore = create<State>()(
           }
           const weekData = computeWeekAggregation(state.docs, state.docRows, next);
           return { schoolVacations: next, weekData };
+        });
+      },
+      clearSchoolVacations: () => {
+        set((state) => {
+          if (state.schoolVacations.length === 0) {
+            return {};
+          }
+          const weekData = computeWeekAggregation(state.docs, state.docRows, []);
+          return { schoolVacations: [], weekData };
         });
       },
       setSchoolVacationActive: (id, active) => {

--- a/frontend/src/components/SchoolVacationManager.tsx
+++ b/frontend/src/components/SchoolVacationManager.tsx
@@ -1,0 +1,547 @@
+import React from "react";
+import { Download, RefreshCw, Trash2, Pencil, Check, ToggleLeft, ToggleRight } from "lucide-react";
+import {
+  useAppStore,
+  type SchoolVacation,
+} from "../app/store";
+import {
+  apiFetchSchoolVacations,
+  type SchoolVacationDownload,
+  type SchoolVacationImport,
+} from "../lib/api";
+import { parseIsoDate } from "../lib/calendar";
+
+const formatDate = (value?: string | null) => {
+  if (!value) return "";
+  const parsed = parseIsoDate(value);
+  if (parsed) {
+    return new Intl.DateTimeFormat("nl-NL", {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    }).format(parsed);
+  }
+  const fallback = new Date(value);
+  if (Number.isNaN(fallback.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat("nl-NL", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  }).format(fallback);
+};
+
+const computeDefaultSchoolYear = () => {
+  const now = new Date();
+  const month = now.getMonth() + 1;
+  const currentYear = now.getFullYear();
+  const startYear = month >= 8 ? currentYear : currentYear - 1;
+  return `${startYear}-${startYear + 1}`;
+};
+
+type DownloadState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready"; payload: SchoolVacationDownload };
+
+type EditState = {
+  id: string;
+  name: string;
+  region: string;
+  startDate: string;
+  endDate: string;
+  notes: string;
+};
+
+function mapImportToVacation(entry: SchoolVacationImport, nowIso: string): SchoolVacation {
+  return {
+    id: entry.id,
+    externalId: entry.id,
+    name: entry.name,
+    region: entry.region,
+    startDate: entry.startDate,
+    endDate: entry.endDate,
+    schoolYear: entry.schoolYear,
+    source: entry.source,
+    label: entry.label,
+    rawText: entry.rawText ?? null,
+    notes: entry.notes ?? null,
+    active: true,
+    createdAt: nowIso,
+    updatedAt: nowIso,
+  };
+}
+
+export default function SchoolVacationManager() {
+  const schoolVacations = useAppStore((s) => s.schoolVacations) ?? [];
+  const addSchoolVacations = useAppStore((s) => s.addSchoolVacations);
+  const updateSchoolVacation = useAppStore((s) => s.updateSchoolVacation);
+  const removeSchoolVacation = useAppStore((s) => s.removeSchoolVacation);
+  const setSchoolVacationActive = useAppStore((s) => s.setSchoolVacationActive);
+
+  const [schoolYear, setSchoolYear] = React.useState<string>(computeDefaultSchoolYear());
+  const [downloadState, setDownloadState] = React.useState<DownloadState>({ status: "idle" });
+  const [isImportOpen, setImportOpen] = React.useState(false);
+  const [selection, setSelection] = React.useState<Record<string, boolean>>({});
+  const [editing, setEditing] = React.useState<EditState | null>(null);
+  const requestIdRef = React.useRef(0);
+
+  const selectedCount = React.useMemo(
+    () => Object.values(selection).filter(Boolean).length,
+    [selection]
+  );
+
+  const fetchVacations = React.useCallback(async () => {
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    setSelection({});
+    setDownloadState({ status: "loading" });
+    try {
+      const payload = await apiFetchSchoolVacations(schoolYear);
+      if (requestId !== requestIdRef.current) {
+        return;
+      }
+      const defaultSelection: Record<string, boolean> = {};
+      payload.vacations.forEach((vac) => {
+        defaultSelection[vac.id] = true;
+      });
+      setSelection(defaultSelection);
+      setDownloadState({ status: "ready", payload });
+    } catch (err: any) {
+      if (requestId !== requestIdRef.current) {
+        return;
+      }
+      setDownloadState({ status: "error", message: err?.message || "Download mislukt" });
+    }
+  }, [schoolYear]);
+
+  const openImportDialog = React.useCallback(() => {
+    setImportOpen(true);
+    setDownloadState({ status: "loading" });
+    setSelection({});
+  }, []);
+
+  React.useEffect(() => {
+    if (!isImportOpen) {
+      return;
+    }
+    fetchVacations();
+  }, [isImportOpen, fetchVacations]);
+
+  const closeImportDialog = React.useCallback(() => {
+    requestIdRef.current += 1;
+    setImportOpen(false);
+    setDownloadState({ status: "idle" });
+    setSelection({});
+  }, []);
+
+  const toggleSelection = (id: string) => {
+    setSelection((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  const selectAll = () => {
+    if (downloadState.status !== "ready") return;
+    const map: Record<string, boolean> = {};
+    downloadState.payload.vacations.forEach((vac) => {
+      map[vac.id] = true;
+    });
+    setSelection(map);
+  };
+
+  const clearSelection = () => setSelection({});
+
+  const handleImport = () => {
+    if (downloadState.status !== "ready") return;
+    const nowIso = new Date().toISOString();
+    const entries = downloadState.payload.vacations
+      .filter((vac) => selection[vac.id])
+      .map((vac) => mapImportToVacation(vac, nowIso));
+    if (!entries.length) {
+      closeImportDialog();
+      return;
+    }
+    addSchoolVacations(entries);
+    closeImportDialog();
+  };
+
+  const startEdit = (vacation: SchoolVacation) => {
+    setEditing({
+      id: vacation.id,
+      name: vacation.name,
+      region: vacation.region,
+      startDate: vacation.startDate,
+      endDate: vacation.endDate,
+      notes: vacation.notes ?? "",
+    });
+  };
+
+  const cancelEdit = () => setEditing(null);
+
+  const saveEdit = () => {
+    if (!editing) return;
+    updateSchoolVacation(editing.id, {
+      name: editing.name.trim() || "Schoolvakantie",
+      region: editing.region.trim() || "Onbekend",
+      startDate: editing.startDate,
+      endDate: editing.endDate,
+      notes: editing.notes.trim() ? editing.notes.trim() : null,
+    });
+    setEditing(null);
+  };
+
+  const removeVacation = (vacation: SchoolVacation) => {
+    const confirmed = window.confirm(
+      `Weet je zeker dat je de vakantie "${vacation.name}" (${vacation.region}) wilt verwijderen?`
+    );
+    if (!confirmed) return;
+    removeSchoolVacation(vacation.id);
+  };
+
+  return (
+    <section className="rounded-2xl border theme-border theme-surface p-4 space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-base font-semibold theme-text">Schoolvakanties</h2>
+          <p className="text-sm theme-muted">
+            Download vakanties van rijksoverheid.nl, beheer metadata en bepaal welke periodes zichtbaar zijn in de planner.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <label className="text-sm theme-muted" htmlFor="schoolyear-input">
+            Schooljaar
+          </label>
+          <input
+            id="schoolyear-input"
+            type="text"
+            value={schoolYear}
+            onChange={(event) => setSchoolYear(event.target.value)}
+            className="w-28 rounded-md border theme-border theme-surface px-2 py-1 text-sm"
+            placeholder="2025-2026"
+          />
+          <button
+            type="button"
+            onClick={openImportDialog}
+            className="inline-flex items-center gap-1 rounded-md border theme-border theme-surface px-3 py-1 text-sm"
+            title="Download schoolvakanties"
+          >
+            <Download size={16} /> Downloaden
+          </button>
+        </div>
+      </div>
+
+      {schoolVacations.length === 0 ? (
+        <div className="rounded-xl border border-dashed theme-border p-4 text-sm theme-muted">
+          Nog geen schoolvakanties toegevoegd. Download eerst een overzicht en kies de periodes die je wilt gebruiken.
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead className="theme-soft">
+              <tr>
+                <th className="px-3 py-2 text-left">Actief</th>
+                <th className="px-3 py-2 text-left">Vakantie</th>
+                <th className="px-3 py-2 text-left">Periode</th>
+                <th className="px-3 py-2 text-left">Bron</th>
+                <th className="px-3 py-2 text-left">Acties</th>
+              </tr>
+            </thead>
+            <tbody>
+              {schoolVacations.map((vacation) => {
+                const period = `${formatDate(vacation.startDate)} – ${formatDate(vacation.endDate)}`;
+                return (
+                  <tr key={vacation.id} className="border-t theme-border align-top">
+                    <td className="px-3 py-2">
+                      <button
+                        type="button"
+                        onClick={() => setSchoolVacationActive(vacation.id, !vacation.active)}
+                        className="flex items-center gap-1 text-sm"
+                        title={vacation.active ? "Deactiveren" : "Activeren"}
+                      >
+                        {vacation.active ? (
+                          <ToggleRight size={18} className="text-emerald-600" />
+                        ) : (
+                          <ToggleLeft size={18} className="theme-muted" />
+                        )}
+                        <span className="sr-only">{vacation.active ? "Actief" : "Inactief"}</span>
+                      </button>
+                    </td>
+                    <td className="px-3 py-2">
+                      <div className="font-medium">{vacation.name}</div>
+                      <div className="text-xs theme-muted">{vacation.region}</div>
+                      {vacation.notes && (
+                        <div className="mt-1 text-xs text-slate-500 whitespace-pre-wrap">{vacation.notes}</div>
+                      )}
+                    </td>
+                    <td className="px-3 py-2">
+                      <div>{period}</div>
+                      <div className="text-xs theme-muted">{vacation.schoolYear}</div>
+                    </td>
+                    <td className="px-3 py-2">
+                      <div className="text-xs theme-muted break-all">{vacation.source}</div>
+                    </td>
+                    <td className="px-3 py-2">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => startEdit(vacation)}
+                          className="inline-flex items-center gap-1 rounded-md border theme-border theme-surface px-2 py-1"
+                          title="Bewerken"
+                        >
+                          <Pencil size={14} /> Bewerken
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => removeVacation(vacation)}
+                          className="inline-flex items-center gap-1 rounded-md border border-red-200 bg-red-50 px-2 py-1 text-red-600"
+                          title="Verwijderen"
+                        >
+                          <Trash2 size={14} /> Verwijderen
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {isImportOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-6">
+          <div className="w-full max-w-3xl rounded-2xl border theme-border theme-surface shadow-lg">
+            <div className="flex items-center justify-between border-b theme-border px-4 py-3">
+              <h3 className="text-base font-semibold">Schoolvakanties importeren</h3>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={fetchVacations}
+                  disabled={downloadState.status === "loading"}
+                  className="inline-flex items-center gap-1 rounded-md border theme-border theme-surface px-2 py-1 text-sm disabled:opacity-50"
+                  title="Opnieuw ophalen"
+                >
+                  <RefreshCw size={14} /> Vernieuwen
+                </button>
+                <button
+                  type="button"
+                  onClick={closeImportDialog}
+                  className="rounded-md border theme-border theme-surface px-2 py-1 text-sm"
+                >
+                  Sluiten
+                </button>
+              </div>
+            </div>
+            <div className="max-h-[70vh] overflow-y-auto px-4 py-4 text-sm">
+              {downloadState.status === "loading" && (
+                <div className="py-6 text-center text-sm theme-muted">Bezig met downloaden…</div>
+              )}
+              {downloadState.status === "error" && (
+                <div className="space-y-3">
+                  <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                    {downloadState.message}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={fetchVacations}
+                    className="inline-flex items-center gap-1 rounded-md border theme-border theme-surface px-3 py-1"
+                  >
+                    <RefreshCw size={16} /> Opnieuw proberen
+                  </button>
+                </div>
+              )}
+              {downloadState.status === "ready" && (
+                <div className="space-y-4">
+                  <div className="flex flex-wrap items-center justify-between gap-2 text-sm theme-muted">
+                    <div>
+                      Bron: <span className="font-medium">{downloadState.payload.source}</span>
+                    </div>
+                    <div>Gehaald op {formatDate(downloadState.payload.retrievedAt)}</div>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2 text-xs">
+                    <button
+                      type="button"
+                      onClick={selectAll}
+                      className="rounded-md border theme-border theme-surface px-2 py-1"
+                    >
+                      Alles selecteren
+                    </button>
+                    <button
+                      type="button"
+                      onClick={clearSelection}
+                      className="rounded-md border theme-border theme-surface px-2 py-1"
+                    >
+                      Niets selecteren
+                    </button>
+                    <span className="theme-muted">{selectedCount} geselecteerd</span>
+                  </div>
+                  <div className="overflow-x-auto rounded-md border theme-border">
+                    <table className="min-w-full text-sm">
+                      <thead className="theme-soft">
+                        <tr>
+                          <th className="px-3 py-2 text-left">Kies</th>
+                          <th className="px-3 py-2 text-left">Vakantie</th>
+                          <th className="px-3 py-2 text-left">Regio</th>
+                          <th className="px-3 py-2 text-left">Periode</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {downloadState.payload.vacations.map((vac) => {
+                          const period = `${formatDate(vac.startDate)} – ${formatDate(vac.endDate)}`;
+                          return (
+                            <tr key={vac.id} className="border-t theme-border">
+                              <td className="px-3 py-2">
+                                <input
+                                  type="checkbox"
+                                  checked={!!selection[vac.id]}
+                                  onChange={() => toggleSelection(vac.id)}
+                                  aria-label={`Selecteer ${vac.name} (${vac.region})`}
+                                />
+                              </td>
+                              <td className="px-3 py-2">
+                                <div className="font-medium">{vac.name}</div>
+                                {vac.notes && (
+                                  <div className="text-xs theme-muted">{vac.notes}</div>
+                                )}
+                              </td>
+                              <td className="px-3 py-2">{vac.region}</td>
+                              <td className="px-3 py-2">{period}</td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
+            </div>
+            <div className="flex items-center justify-between border-t theme-border px-4 py-3 text-sm">
+              {downloadState.status === "ready" ? (
+                <span className="theme-muted">
+                  {downloadState.payload.vacations.length} vakanties gevonden · {selectedCount} geselecteerd
+                </span>
+              ) : (
+                <span className="theme-muted">Schooljaar {schoolYear}</span>
+              )}
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={closeImportDialog}
+                  className="rounded-md border theme-border theme-surface px-3 py-1"
+                >
+                  Annuleren
+                </button>
+                <button
+                  type="button"
+                  onClick={handleImport}
+                  disabled={downloadState.status !== "ready" || selectedCount === 0}
+                  className="inline-flex items-center gap-1 rounded-md bg-slate-900 px-3 py-1 text-white disabled:opacity-40"
+                >
+                  <Check size={16} /> Importeren
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {editing && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-6">
+          <div className="w-full max-w-md rounded-2xl border theme-border theme-surface shadow-lg">
+            <div className="flex items-center justify-between border-b theme-border px-4 py-3">
+              <h3 className="text-base font-semibold">Vakantie bewerken</h3>
+              <button
+                type="button"
+                onClick={cancelEdit}
+                className="rounded-md border theme-border theme-surface px-2 py-1 text-sm"
+              >
+                Sluiten
+              </button>
+            </div>
+            <div className="px-4 py-4 space-y-3 text-sm">
+              <div>
+                <label className="block text-xs theme-muted mb-1" htmlFor="edit-name">
+                  Naam
+                </label>
+                <input
+                  id="edit-name"
+                  type="text"
+                  value={editing.name}
+                  onChange={(event) => setEditing({ ...editing, name: event.target.value })}
+                  className="w-full rounded-md border theme-border theme-surface px-2 py-1"
+                />
+              </div>
+              <div>
+                <label className="block text-xs theme-muted mb-1" htmlFor="edit-region">
+                  Regio
+                </label>
+                <input
+                  id="edit-region"
+                  type="text"
+                  value={editing.region}
+                  onChange={(event) => setEditing({ ...editing, region: event.target.value })}
+                  className="w-full rounded-md border theme-border theme-surface px-2 py-1"
+                />
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div>
+                  <label className="block text-xs theme-muted mb-1" htmlFor="edit-start">
+                    Startdatum
+                  </label>
+                  <input
+                    id="edit-start"
+                    type="date"
+                    value={editing.startDate}
+                    onChange={(event) => setEditing({ ...editing, startDate: event.target.value })}
+                    className="w-full rounded-md border theme-border theme-surface px-2 py-1"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs theme-muted mb-1" htmlFor="edit-end">
+                    Einddatum
+                  </label>
+                  <input
+                    id="edit-end"
+                    type="date"
+                    value={editing.endDate}
+                    onChange={(event) => setEditing({ ...editing, endDate: event.target.value })}
+                    className="w-full rounded-md border theme-border theme-surface px-2 py-1"
+                  />
+                </div>
+              </div>
+              <div>
+                <label className="block text-xs theme-muted mb-1" htmlFor="edit-notes">
+                  Notities (optioneel)
+                </label>
+                <textarea
+                  id="edit-notes"
+                  value={editing.notes}
+                  onChange={(event) => setEditing({ ...editing, notes: event.target.value })}
+                  className="w-full rounded-md border theme-border theme-surface px-2 py-1"
+                  rows={3}
+                />
+              </div>
+            </div>
+            <div className="flex items-center justify-end gap-2 border-t theme-border px-4 py-3 text-sm">
+              <button
+                type="button"
+                onClick={cancelEdit}
+                className="rounded-md border theme-border theme-surface px-3 py-1"
+              >
+                Annuleren
+              </button>
+              <button
+                type="button"
+                onClick={saveEdit}
+                className="inline-flex items-center gap-1 rounded-md bg-slate-900 px-3 py-1 text-white"
+              >
+                <Check size={16} /> Opslaan
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/SchoolVacationManager.tsx
+++ b/frontend/src/components/SchoolVacationManager.tsx
@@ -54,7 +54,7 @@ const computeSchoolYearOptions = () => {
   const month = now.getMonth() + 1;
   const currentYear = now.getFullYear();
   const currentStartYear = month >= 8 ? currentYear : currentYear - 1;
-  return [0, 1, 2].map((offset) => {
+  return [0, 1].map((offset) => {
     const startYear = currentStartYear + offset;
     const value = `${startYear}-${startYear + 1}`;
     return { value, label: value };

--- a/frontend/src/components/SchoolVacationManager.tsx
+++ b/frontend/src/components/SchoolVacationManager.tsx
@@ -40,6 +40,25 @@ const computeDefaultSchoolYear = () => {
   return `${startYear}-${startYear + 1}`;
 };
 
+const computeSchoolYearOptions = () => {
+  const now = new Date();
+  const month = now.getMonth() + 1;
+  const currentYear = now.getFullYear();
+  const startYear = month >= 8 ? currentYear : currentYear - 1;
+  const currentLabel = `${startYear}-${startYear + 1}`;
+  const nextLabel = `${startYear + 1}-${startYear + 2}`;
+  return [
+    {
+      value: currentLabel,
+      label: `Huidig jaar – volgend jaar (${currentLabel})`,
+    },
+    {
+      value: nextLabel,
+      label: `Volgend jaar – jaar daarop (${nextLabel})`,
+    },
+  ];
+};
+
 type DownloadState =
   | { status: "idle" }
   | { status: "loading" }
@@ -81,7 +100,10 @@ export default function SchoolVacationManager() {
   const removeSchoolVacation = useAppStore((s) => s.removeSchoolVacation);
   const setSchoolVacationActive = useAppStore((s) => s.setSchoolVacationActive);
 
-  const [schoolYear, setSchoolYear] = React.useState<string>(computeDefaultSchoolYear());
+  const schoolYearOptions = React.useMemo(() => computeSchoolYearOptions(), []);
+  const [schoolYear, setSchoolYear] = React.useState<string>(
+    () => schoolYearOptions[0]?.value ?? computeDefaultSchoolYear()
+  );
   const [downloadState, setDownloadState] = React.useState<DownloadState>({ status: "idle" });
   const [isImportOpen, setImportOpen] = React.useState(false);
   const [selection, setSelection] = React.useState<Record<string, boolean>>({});
@@ -250,14 +272,18 @@ export default function SchoolVacationManager() {
           <label className="text-sm theme-muted" htmlFor="schoolyear-input">
             Schooljaar
           </label>
-          <input
+          <select
             id="schoolyear-input"
-            type="text"
             value={schoolYear}
             onChange={(event) => setSchoolYear(event.target.value)}
-            className="w-28 rounded-md border theme-border theme-surface px-2 py-1 text-sm"
-            placeholder="2025-2026"
-          />
+            className="w-56 rounded-md border theme-border theme-surface px-2 py-1 text-sm"
+          >
+            {schoolYearOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
           <button
             type="button"
             onClick={openImportDialog}
@@ -278,7 +304,9 @@ export default function SchoolVacationManager() {
           <table className="min-w-full text-sm">
             <thead className="theme-soft">
               <tr>
-                <th className="px-3 py-2 text-left">Actief</th>
+                <th className="px-3 py-2 text-left w-16">
+                  <span className="sr-only">Actief</span>
+                </th>
                 <th className="px-3 py-2 text-left">Vakantie</th>
                 <th className="px-3 py-2 text-left">Periode</th>
                 <th className="px-3 py-2 text-left">Bron</th>
@@ -295,7 +323,11 @@ export default function SchoolVacationManager() {
                         type="button"
                         onClick={() => setSchoolVacationActive(vacation.id, !vacation.active)}
                         className="flex items-center gap-1 text-sm"
-                        title={vacation.active ? "Deactiveren" : "Activeren"}
+                        title={
+                          vacation.active
+                            ? "Vakantie is actief – klik om te deactiveren"
+                            : "Vakantie is inactief – klik om te activeren"
+                        }
                       >
                         {vacation.active ? (
                           <ToggleRight size={18} className="text-emerald-600" />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -113,6 +113,27 @@ export type CommitResponse = {
   version: StudyGuideVersion;
 };
 
+export type SchoolVacationImport = {
+  id: string;
+  name: string;
+  region: string;
+  startDate: string;
+  endDate: string;
+  schoolYear: string;
+  source: string;
+  label: string;
+  rawText?: string | null;
+  notes?: string | null;
+};
+
+export type SchoolVacationDownload = {
+  schoolYear: string;
+  source: string;
+  retrievedAt: string;
+  title?: string | null;
+  vacations: SchoolVacationImport[];
+};
+
 function resolveApiBase(): string {
   const envBase = (import.meta.env.VITE_API_BASE ?? "").trim();
   if (envBase) {
@@ -200,6 +221,17 @@ export async function apiGetStudyGuideVersions(guideId: string): Promise<StudyGu
     throw new Error(`guide_versions failed: ${r.status}`);
   }
   return (await r.json()) as StudyGuideVersion[];
+}
+
+export async function apiFetchSchoolVacations(
+  schoolYear: string
+): Promise<SchoolVacationDownload> {
+  const params = new URLSearchParams({ schoolYear });
+  const r = await fetch(`${BASE}/api/school-vacations?${params.toString()}`);
+  if (!r.ok) {
+    throw new Error(`school_vacations failed: ${r.status}`);
+  }
+  return (await r.json()) as SchoolVacationDownload;
 }
 
 export async function apiGetStudyGuideDiff(

--- a/frontend/src/pages/Matrix.tsx
+++ b/frontend/src/pages/Matrix.tsx
@@ -9,6 +9,7 @@ import {
   Trash2,
   Pencil,
   Undo2,
+  Sun,
 } from "lucide-react";
 import {
   useAppStore,
@@ -16,6 +17,7 @@ import {
   type WeekInfo,
   type WeekData,
   type CustomHomeworkEntry,
+  type VacationWeekInfo,
 } from "../app/store";
 import {
   formatRange,
@@ -584,6 +586,7 @@ export default function Matrix() {
   const huiswerkWeergave = useAppStore((s) => s.huiswerkWeergave);
   const docs = useAppStore((s) => s.docs) ?? [];
   const weekData = useAppStore((s) => s.weekData);
+  const vacationsByWeek = weekData.vacationsByWeek ?? {};
   const customHomework = useAppStore((s) => s.customHomework);
   const addCustomHomework = useAppStore((s) => s.addCustomHomework);
   const removeCustomHomework = useAppStore((s) => s.removeCustomHomework);
@@ -864,6 +867,10 @@ export default function Matrix() {
                 <th className="px-4 py-2 text-left whitespace-nowrap">Vak</th>
                 {weeks.map((w) => {
                   const isCurrent = w.id === currentWeekId;
+                  const vacationEntries: VacationWeekInfo[] = vacationsByWeek[w.id] ?? [];
+                  const vacationLabel = vacationEntries
+                    .map((vac) => `${vac.name} (${vac.region})`)
+                    .join(" • ");
                   const headerStyle: React.CSSProperties | undefined = isCurrent
                     ? {
                         backgroundColor: currentWeekHighlightColor,
@@ -881,6 +888,12 @@ export default function Matrix() {
                     >
                       <div className="font-medium">Week {w.nr}</div>
                       <div className="text-xs theme-muted">{formatRange(w)}</div>
+                      {vacationLabel && (
+                        <div className="mt-1 flex items-center gap-1 text-xs text-amber-700">
+                          <Sun size={12} />
+                          <span>{vacationLabel}</span>
+                        </div>
+                      )}
                     </th>
                   );
                 })}

--- a/frontend/src/pages/Uploads.tsx
+++ b/frontend/src/pages/Uploads.tsx
@@ -8,6 +8,8 @@ import {
   ClipboardList,
   AlertTriangle,
   XOctagon,
+  ToggleLeft,
+  ToggleRight,
 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import type { DocRecord } from "../app/store";
@@ -1125,7 +1127,7 @@ export default function Uploads() {
             <table className="table-auto min-w-max text-sm">
               <thead className="text-xs font-medium theme-muted border-b theme-border">
                 <tr>
-                  <th className="px-4 py-3 text-center font-medium">
+                  <th className="px-4 py-3 text-center font-medium w-16">
                     <span className="sr-only">Gebruik</span>
                   </th>
                   <th className="px-4 py-3 text-left font-medium">Acties</th>
@@ -1225,11 +1227,14 @@ export default function Uploads() {
                   return (
                     <tr key={`${entry.kind}-${d.fileId}-${entry.kind === "pending" ? entry.review.parseId : d.versionId ?? "latest"}`} className={rowClassName}>
                       <td className="px-4 py-3 text-center align-middle">
-                        <input
-                          type="checkbox"
-                          className="h-4 w-4"
-                          checked={entry.kind === "active" ? d.enabled : false}
-                          onChange={() => entry.kind === "active" && toggleGebruik(d)}
+                        <button
+                          type="button"
+                          onClick={() => entry.kind === "active" && toggleGebruik(d)}
+                          disabled={entry.kind !== "active"}
+                          className={clsx(
+                            "inline-flex items-center justify-center",
+                            entry.kind !== "active" && "cursor-not-allowed opacity-40"
+                          )}
                           aria-label={
                             entry.kind === "active"
                               ? d.enabled
@@ -1240,12 +1245,29 @@ export default function Uploads() {
                           title={
                             entry.kind === "active"
                               ? d.enabled
-                                ? `Gebruik uitschakelen voor ${d.bestand}`
-                                : `Gebruik inschakelen voor ${d.bestand}`
-                              : "Eerst review afronden"
+                                ? `${d.bestand} is actief – klik om te deactiveren`
+                                : `${d.bestand} is inactief – klik om te activeren`
+                              : "Document staat in review – activeren niet mogelijk"
                           }
-                          disabled={entry.kind !== "active"}
-                        />
+                        >
+                          {entry.kind === "active" ? (
+                            d.enabled ? (
+                              <ToggleRight size={18} className="text-emerald-600" />
+                            ) : (
+                              <ToggleLeft size={18} className="theme-muted" />
+                            )
+                          ) : (
+                            <ToggleLeft size={18} className="theme-muted" />
+                          )}
+                          <span className="sr-only">
+                            {entry.kind === "active"
+                              ? d.enabled
+                                ? "Actief"
+                                : "Inactief"
+                              : "Niet beschikbaar"
+                            }
+                          </span>
+                        </button>
                       </td>
                       <td className="px-4 py-3 align-top">
                         <div className="flex flex-wrap gap-2 justify-center sm:justify-start">

--- a/frontend/src/pages/Uploads.tsx
+++ b/frontend/src/pages/Uploads.tsx
@@ -269,6 +269,7 @@ export default function Uploads() {
   const [isUploading, setUploading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
   const [page, setPage] = React.useState(1);
+  const [activeTab, setActiveTab] = React.useState<"documents" | "vacations">("documents");
   const fileInputRef = React.useRef<HTMLInputElement | null>(null);
   const dragCounterRef = React.useRef(0);
   const [isDragOver, setIsDragOver] = React.useState(false);
@@ -874,11 +875,57 @@ export default function Uploads() {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [detailDoc]);
 
+  React.useEffect(() => {
+    if (activeTab === "documents" || !detailDoc) {
+      return;
+    }
+    setDetailDoc(null);
+  }, [activeTab, detailDoc]);
+
+  const tabButtonClass = (tab: "documents" | "vacations") =>
+    clsx(
+      "rounded-full px-3 py-1 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--app-border)]",
+      activeTab === tab
+        ? "bg-[var(--app-accent)] text-white shadow"
+        : "theme-surface theme-muted hover:bg-slate-100/80"
+    );
+
+  const headingLabel =
+    activeTab === "documents" ? "Uploads & Documentbeheer" : "Schoolvakanties";
+
   return (
     <div className="space-y-4">
-      <div className="text-lg font-semibold theme-text">Uploads &amp; Documentbeheer</div>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="text-lg font-semibold theme-text">{headingLabel}</div>
+        <div
+          role="tablist"
+          aria-label="Beheer"
+          className="inline-flex items-center gap-1 rounded-full border theme-border theme-surface p-1 shadow-sm"
+        >
+          <button
+            type="button"
+            role="tab"
+            aria-selected={activeTab === "documents"}
+            className={tabButtonClass("documents")}
+            onClick={() => setActiveTab("documents")}
+          >
+            Documenten
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={activeTab === "vacations"}
+            className={tabButtonClass("vacations")}
+            onClick={() => setActiveTab("vacations")}
+          >
+            Schoolvakanties
+          </button>
+        </div>
+      </div>
 
-      {pendingReviewCount > 0 && (
+      {activeTab === "documents" ? (
+        <>
+          {pendingReviewCount > 0 && (
         <div className="rounded-2xl border border-amber-200 bg-amber-50 p-4">
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div>
@@ -953,10 +1000,10 @@ export default function Uploads() {
             )}
           </div>
         </div>
-      )}
+          )}
 
-      {/* Uploadblok */}
-      <div className="rounded-2xl border theme-border theme-surface p-4">
+          {/* Uploadblok */}
+          <div className="rounded-2xl border theme-border theme-surface p-4">
         <div className="mb-1 font-medium theme-text">Bestanden uploaden</div>
         <div className="text-sm theme-muted">
           Kies een <strong>PDF</strong> of <strong>DOCX</strong>. Metadata wordt automatisch herkend.
@@ -1048,8 +1095,6 @@ export default function Uploads() {
           </div>
         </div>
       </div>
-
-      <SchoolVacationManager />
 
       {/* Filters */}
       <div
@@ -1388,8 +1433,13 @@ export default function Uploads() {
         )}
       </div>
 
+        </>
+      ) : (
+        <SchoolVacationManager />
+      )}
+
       {/* Detail modal */}
-      {detailDoc && (
+      {activeTab === "documents" && detailDoc && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-6"
           role="presentation"

--- a/frontend/src/pages/Uploads.tsx
+++ b/frontend/src/pages/Uploads.tsx
@@ -33,6 +33,7 @@ import {
 } from "../lib/api";
 import { parseIsoDate } from "../lib/calendar";
 import { useDocumentPreview } from "../components/DocumentPreviewProvider";
+import SchoolVacationManager from "../components/SchoolVacationManager";
 import { useFocusTrap } from "../lib/useFocusTrap";
 import {
   DiffRowsList,
@@ -1045,6 +1046,8 @@ export default function Uploads() {
           </div>
         </div>
       </div>
+
+      <SchoolVacationManager />
 
       {/* Filters */}
       <div

--- a/frontend/src/pages/WeekOverview.tsx
+++ b/frontend/src/pages/WeekOverview.tsx
@@ -10,6 +10,7 @@ import {
   Trash2,
   Pencil,
   Undo2,
+  Sun,
 } from "lucide-react";
 import {
   useAppStore,
@@ -17,11 +18,12 @@ import {
   type WeekInfo,
   type WeekData,
   type CustomHomeworkEntry,
+  type VacationWeekInfo,
 } from "../app/store";
 import { formatRange, calcCurrentWeekIdx } from "../lib/weekUtils";
 import { splitHomeworkItems } from "../lib/textUtils";
 import { useDocumentPreview } from "../components/DocumentPreviewProvider";
-import { deriveIsoYearForWeek } from "../lib/calendar";
+import { deriveIsoYearForWeek, parseIsoDate } from "../lib/calendar";
 import { hasMeaningfulContent } from "../lib/contentUtils";
 
 type HomeworkItem = {
@@ -621,6 +623,7 @@ export default function WeekOverview() {
   const hasActiveDocs = activeDocs.length > 0;
   const weeks = weekData.weeks ?? [];
   const byWeek = weekData.byWeek ?? {};
+  const vacationsByWeek = weekData.vacationsByWeek ?? {};
   const hasWeekData = weeks.length > 0;
 
   const niveauOptions = React.useMemo(
@@ -707,10 +710,30 @@ export default function WeekOverview() {
   const weekNumber = week?.nr ?? 0;
   const weekKey = week?.id ?? `wk-${weekNumber}`;
   const dataForActiveWeek = week ? byWeek[week.id] || {} : {};
+  const vacationsForWeek: VacationWeekInfo[] = week ? vacationsByWeek[week.id] ?? [] : [];
   const goThisWeek = React.useCallback(() => {
     if (!weeks.length) return;
     setWeekIdxWO(calcCurrentWeekIdx(weeks));
   }, [weeks, setWeekIdxWO]);
+
+  const dateFormatter = React.useMemo(
+    () => new Intl.DateTimeFormat("nl-NL", { day: "numeric", month: "short", year: "numeric" }),
+    []
+  );
+
+  const formatVacationPeriod = React.useCallback(
+    (vac: VacationWeekInfo): string => {
+      const start = parseIsoDate(vac.startDate);
+      const end = parseIsoDate(vac.endDate);
+      const startLabel = start ? dateFormatter.format(start) : vac.startDate;
+      const endLabel = end ? dateFormatter.format(end) : vac.endDate;
+      if (startLabel && endLabel && startLabel !== endLabel) {
+        return `${startLabel} – ${endLabel}`;
+      }
+      return startLabel || endLabel || vac.label;
+    },
+    [dateFormatter]
+  );
 
   const findDocForWeek = React.useCallback(
     (docsForVak: DocRecord[], info?: WeekInfo) => {
@@ -735,6 +758,21 @@ export default function WeekOverview() {
           Week {week?.nr ?? "—"} · {week ? formatRange(week) : "Geen data"}
         </div>
       </div>
+
+      {vacationsForWeek.length > 0 && (
+        <div className="mb-4 rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm">
+          <div className="flex items-center gap-2 font-semibold text-amber-900">
+            <Sun size={16} /> Schoolvakantie
+          </div>
+          <ul className="mt-2 space-y-1 text-amber-800">
+            {vacationsForWeek.map((vac) => (
+              <li key={`${vac.id}-${week?.id ?? "wk"}`}>
+                <span className="font-medium">{vac.name}</span> ({vac.region}) · {formatVacationPeriod(vac)}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       <div className="mb-4 flex flex-wrap gap-2 items-center">
         <button

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import asyncio
+import inspect
+
+import pytest
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
+    """Allow async test functions without requiring pytest-asyncio."""
+    if inspect.iscoroutinefunction(pyfuncitem.obj):
+        asyncio.run(pyfuncitem.obj(**pyfuncitem.funcargs))
+        return True
+    return None

--- a/tests/data/school_vacations_sample.html
+++ b/tests/data/school_vacations_sample.html
@@ -67,13 +67,13 @@
         <tr>
           <th scope="row">Zomervakantie</th>
           <td>
-            <p>4 juli 2026 t/m 16 augustus 2026</p>
+            <p>4 juli t/m 16 augustus 2026</p>
           </td>
           <td>
-            <p>11 juli 2026 t/m 23 augustus 2026</p>
+            <p>11 juli t/m 23 augustus 2026</p>
           </td>
           <td>
-            <p>18 juli 2026 t/m 30 augustus 2026</p>
+            <p>18 juli t/m 30 augustus 2026</p>
           </td>
         </tr>
       </tbody>

--- a/tests/data/school_vacations_sample.html
+++ b/tests/data/school_vacations_sample.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <title>Schoolvakanties 2025-2026</title>
+  </head>
+  <body>
+    <h1>Overzicht schoolvakanties 2025-2026</h1>
+    <table>
+      <thead>
+        <tr>
+          <th>Vakantie</th>
+          <th>Regio Noord</th>
+          <th>Regio Midden</th>
+          <th>Regio Zuid</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">Herfstvakantie</th>
+          <td>
+            <p>18 oktober 2025 t/m 26 oktober 2025</p>
+          </td>
+          <td>
+            <p>18 oktober 2025 t/m 26 oktober 2025</p>
+          </td>
+          <td>
+            <p>18 oktober 2025 t/m 26 oktober 2025</p>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Kerstvakantie</th>
+          <td>
+            <p>20 december 2025 t/m 4 januari 2026</p>
+          </td>
+          <td>
+            <p>20 december 2025 t/m 4 januari 2026</p>
+          </td>
+          <td>
+            <p>20 december 2025 t/m 4 januari 2026</p>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Voorjaarsvakantie</th>
+          <td>
+            <p>14 februari 2026 t/m 22 februari 2026</p>
+          </td>
+          <td>
+            <p>21 februari 2026 t/m 1 maart 2026</p>
+          </td>
+          <td>
+            <p>21 februari 2026 t/m 1 maart 2026</p>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Meivakantie</th>
+          <td>
+            <p>25 april 2026 t/m 3 mei 2026 (advies)</p>
+          </td>
+          <td>
+            <p>2 mei 2026 t/m 10 mei 2026</p>
+          </td>
+          <td>
+            <p>2 mei 2026 t/m 10 mei 2026</p>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Zomervakantie</th>
+          <td>
+            <p>4 juli 2026 t/m 16 augustus 2026</p>
+          </td>
+          <td>
+            <p>11 juli 2026 t/m 23 augustus 2026</p>
+          </td>
+          <td>
+            <p>18 juli 2026 t/m 30 augustus 2026</p>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/tests/test_school_vacations.py
+++ b/tests/test_school_vacations.py
@@ -23,6 +23,14 @@ def test_parse_school_vacations_sample():
     assert "18 oktober" in first.label
     assert "advies" not in first.label.lower()
 
+    summer_north = next(
+        vac
+        for vac in vacations
+        if vac.name == "Zomervakantie" and vac.region.lower() == "noord"
+    )
+    assert summer_north.start_date == "2026-07-04"
+    assert summer_north.end_date == "2026-08-16"
+
 
 @pytest.mark.asyncio
 async def test_fetch_school_vacations_with_stub():

--- a/tests/test_school_vacations.py
+++ b/tests/test_school_vacations.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.app import app
+from backend.school_vacations import parse_school_vacations, fetch_school_vacations
+
+
+SAMPLE_HTML = Path("tests/data/school_vacations_sample.html").read_text(encoding="utf-8")
+
+
+def test_parse_school_vacations_sample():
+    vacations = parse_school_vacations(SAMPLE_HTML, "2025-2026", "https://example")
+    assert len(vacations) == 15
+    first = vacations[0]
+    assert first.name == "Herfstvakantie"
+    assert first.region.lower() == "noord"
+    assert first.start_date == "2025-10-18"
+    assert first.end_date == "2025-10-26"
+    assert first.school_year == "2025-2026"
+    assert first.source == "https://example"
+    assert "18 oktober" in first.label
+    assert "advies" not in first.label.lower()
+
+
+@pytest.mark.asyncio
+async def test_fetch_school_vacations_with_stub():
+    async def fake_get(url: str) -> str:
+        assert "2025-2026" in url
+        return SAMPLE_HTML
+
+    data = await fetch_school_vacations("2025-2026", http_get=fake_get)
+    assert data["schoolYear"] == "2025-2026"
+    assert data["source"].endswith("2025-2026")
+    assert len(data["vacations"]) == 15
+
+
+def test_api_school_vacations(monkeypatch):
+    async def fake_fetch(school_year: str):
+        assert school_year == "2025-2026"
+        return {
+            "schoolYear": school_year,
+            "source": "https://example", 
+            "retrievedAt": "2024-01-01T00:00:00+00:00",
+            "title": "Schoolvakanties",
+            "vacations": [
+                {
+                    "id": "herfst-noord",
+                    "name": "Herfstvakantie",
+                    "region": "Noord",
+                    "start_date": "2025-10-18",
+                    "end_date": "2025-10-26",
+                    "school_year": school_year,
+                    "source": "https://example",
+                    "label": "18 oktober 2025 t/m 26 oktober 2025",
+                    "raw_text": "18 oktober 2025 t/m 26 oktober 2025",
+                    "notes": None,
+                }
+            ],
+        }
+
+    monkeypatch.setattr("backend.app.fetch_school_vacations", fake_fetch)
+    client = TestClient(app)
+    response = client.get("/api/school-vacations", params={"schoolYear": "2025-2026"})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["schoolYear"] == "2025-2026"
+    assert payload["vacations"] == [
+        {
+            "id": "herfst-noord",
+            "name": "Herfstvakantie",
+            "region": "Noord",
+            "startDate": "2025-10-18",
+            "endDate": "2025-10-26",
+            "schoolYear": "2025-2026",
+            "source": "https://example",
+            "label": "18 oktober 2025 t/m 26 oktober 2025",
+            "rawText": "18 oktober 2025 t/m 26 oktober 2025",
+            "notes": None,
+        }
+    ]


### PR DESCRIPTION
## Summary
- add a backend parser/fetcher for rijksoverheid school vacations with an `/api/school-vacations` endpoint
- extend the frontend store, API client, and uploads dashboard with a school vacation manager and aggregation visibility
- cover the feature with backend fixtures/tests and a pytest hook for async tests

## Testing
- npm test -- --watch=false
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d320595c248322ab42142903898bc9