### PR TITLE
Sanitize upload filenames and add security test

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -43,9 +43,13 @@ def _load_latest() -> dict:
 async def upload(file: UploadFile = File(...)):
     tmp_dir = Path("uploads")
     tmp_dir.mkdir(exist_ok=True)
-    tmp_path = tmp_dir / file.filename
+
+    filename = Path(file.filename or "").name or "upload.bin"
+    tmp_path = tmp_dir / filename
+
     with tmp_path.open("wb") as fh:
-        fh.write(await file.read())
+        while chunk := await file.read(65536):
+            fh.write(chunk)
     parse_id, model = parse_to_normalized(str(tmp_path))
     return {
         "parse_id": parse_id,

--- a/tests/test_upload_security.py
+++ b/tests/test_upload_security.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import sys, pathlib; sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import io
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+import backend.main as backend_app
+
+
+class _DummyWarning:
+    def model_dump(self) -> dict[str, str]:
+        return {"warning": "dummy"}
+
+
+def test_upload_sanitizes_and_streams(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    captured: dict[str, str] = {}
+
+    def fake_parse_to_normalized(path: str):
+        captured["path"] = path
+        return "parse-id", SimpleNamespace(warnings=[_DummyWarning()])
+
+    monkeypatch.setattr(backend_app, "parse_to_normalized", fake_parse_to_normalized)
+
+    client = TestClient(backend_app.app)
+
+    response = client.post(
+        "/api/uploads",
+        files={
+            "file": (
+                "../evil.docx",
+                io.BytesIO(b"malicious"),
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            )
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload == {"parse_id": "parse-id", "status": "ready", "warnings": [{"warning": "dummy"}]}
+
+    assert "path" in captured
+
+    saved_path = Path(captured["path"])
+    assert saved_path.parent == Path("uploads")
+    assert saved_path.name == "evil.docx"
+
+    resolved_path = saved_path.resolve()
+    assert resolved_path.parent == tmp_path / "uploads"
+    assert resolved_path.read_bytes() == b"malicious"


### PR DESCRIPTION
## Summary
- normalize upload filenames before saving and stream file writes in chunks
- add regression test ensuring path traversal names are sanitized and parser still runs

## Testing
- pytest tests/test_upload_security.py

------
https://chatgpt.com/codex/tasks/task_e_68d31f390cfc832283c444a1aa084c53