### PR TITLE
Voeg AGENTS-richtlijnen toe voor repository, backend en frontend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Richtlijnen voor deze repository
+
+Deze afspraken gelden voor de volledige broncode en documentatie in `vlier-planner`.
+
+- Schrijf commit- en PR-teksten in het Nederlands.
+- Houd gebruikersgerichte teksten (UI, notificaties, documentatie) in het Nederlands; technische identifier- en codecommentaar mag in het Engels zolang het consequent is binnen het bestand.
+- Pas `VERSION.ini` alleen aan wanneer je een release voorbereidt en voer dan direct `npm run sync-version` uit vanuit de map `frontend` zodat versies gelijk blijven.
+- Voeg bij wijzigingen in documentatie of configuratie steeds een korte toelichting toe in dezelfde commit zodat reviewers de context hebben.
+- Draai waar mogelijk de relevante tests voor de onderdelen die je aanpast (zie de meer specifieke AGENTS in submappen) en vermeld het resultaat in je eindrapportage.
+- Werk lockfiles (`package-lock.json`, `backend/requirements.txt` e.d.) altijd mee als je afhankelijkheden wijzigt.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,0 +1,10 @@
+# Backend richtlijnen
+
+Deze aanwijzingen gelden voor alle bestanden in `backend/`.
+
+- Python-code gebruikt type hints en Pydantic-modellen; voeg annotaties toe bij nieuwe functies en parameters.
+- Gebruik FastAPI-conventies: valideer input met `pydantic`-modellen of `Query`/`Body` parameters en werp `HTTPException` bij foutscenario's.
+- Houd bestands- en functienamen beschrijvend en in het Engels; vertaal user-facing strings naar het Nederlands.
+- Bij nieuwe afhankelijkheden update je `backend/requirements.txt` en beschrijf je in de commit waarom ze nodig zijn.
+- Schrijf waar mogelijk doctests of unit-tests in `tests/` (pytest). Als testen niet haalbaar zijn, motiveer dat in de PR-beschrijving.
+- Respecteer de bestaande fallback-imports voor bundling; voeg geen nieuwe `try/except` rond imports toe tenzij het platformverschillen oplost.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,11 @@
+# Frontend richtlijnen
+
+Deze afspraken gelden voor alle bestanden in `frontend/` en de onderliggende mappen.
+
+- Gebruik functionele React-componenten met hooks; voorkom klassecomponenten.
+- Typ alle nieuwe state en props met TypeScript types of interfaces. Houd shared types in `frontend/src/app` of `frontend/src/lib` als ze door meerdere modules worden gebruikt.
+- UI-tekst en validatiemeldingen zijn in het Nederlands. Houd component- en variabelenamen in het Engels voor consistentie met de bestaande code.
+- Styling verloopt via Tailwind utility-klassen en bestaande CSS-modules; voeg geen globale CSS toe zonder noodzaak.
+- Als je nieuwe iconen nodig hebt, kies ze uit `lucide-react` om de bundel consistent te houden.
+- Voor nieuwe logica schrijf je Vitest/Testing Library tests waar dat zinvol is. Motiveer in de PR als een test niet haalbaar is.
+- Draai `npm test` bij wijzigingen in `src/` en vermeld het resultaat in je rapportage.


### PR DESCRIPTION
## Samenvatting
- toegevoegd AGENTS.md in de root met algemene werkrichtlijnen voor versiebeheer en documentatie
- toegevoegd backend/AGENTS.md met afspraken rond FastAPI, type hints en testen
- toegevoegd frontend/AGENTS.md met richtlijnen voor React/TypeScript, styling en testbeleid

## Testen
- niet uitgevoerd (alleen documentatie-updates)


------
https://chatgpt.com/codex/tasks/task_e_68d7d00ff5948322bc9cb393446909d6