### PR TITLE
Bereid v2.0.0-release voor

### DIFF
--- a/VERSION.ini
+++ b/VERSION.ini
@@ -1,2 +1,2 @@
 [app]
-version = 1.4.1
+version = 2.0.0

--- a/docs/release-v2.0.0.md
+++ b/docs/release-v2.0.0.md
@@ -1,0 +1,27 @@
+# Release v2.0.0
+
+Deze handleiding beschrijft hoe we de eerste stabiele release (v2.0.0) van Vlier Planner voorbereiden en communiceren.
+
+## Stappenplan voor publicatie
+1. **Versie bepalen**  
+   - Actualiseer `VERSION.ini` naar `2.0.0` en voer in `frontend/` `npm run sync-version` uit zodat de frontend dezelfde versie gebruikt.  
+   - Controleer dat het versienummer zichtbaar is in de app (instellingen → updates) na een lokale build.
+2. **Code valideren**  
+   - Draai `pytest` voor de backend en `npm test` voor de frontend.  
+   - Bouw de distributie met `python tools/build_frontend.py` en `pyinstaller VlierPlanner.spec` voor een end-to-end rooktest.
+3. **Release candidate controleren**  
+   - Volg de checklist uit `docs/windows-update-testing.md` om de automatische updateflow te valideren.  
+   - Test minimaal één import van een studiewijzer (DOCX of PDF) en controleer week-, matrix- en eventoverzicht.
+4. **Installers en artifacts publiceren**  
+   - Maak een Git-tag `v2.0.0` en upload `VlierPlanner-Setup-2.0.0.exe` plus de standalone `VlierPlanner-2.0.0.exe` naar de release.  
+   - Voeg een `SHA256: ...` regel toe aan de releasenotes zodat de automatische updater de download kan verifiëren.
+5. **Communicatie**  
+   - Publiceer de releasenotes (zie hieronder) op het intranet of de projectpagina.  
+   - Informeer pilotdocenten en leerlingen dat ze de nieuwe versie via de automatische update ontvangen.
+
+## Releasenotes v2.0.0
+- Eerste publieke versie met volledige studiewijzer-workflow: uploaden, normaliseren, reviewen en publiceren vanuit één applicatie.  
+- Complete plannerervaring met week- en matrixoverzicht, filterbare eventlijst en thema-editor voor een gepersonaliseerde look & feel.  
+- Onboarding-tour voor nieuwe gebruikers en automatische updatecontrole met optionele handmatige installatie.  
+- Ingebouwde ondersteuning voor schoolvakanties via rijksoverheid.nl zodat lesvrije dagen meteen zichtbaar zijn in de planning.  
+- Windows distributie met geïntegreerde frontend-build en automatische self-update voor toekomstige releases.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stuplan-frontend",
-  "version": "1.4.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stuplan-frontend",
-      "version": "1.4.1",
+      "version": "2.0.0",
       "dependencies": {
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stuplan-frontend",
   "private": true,
-  "version": "1.4.1",
+  "version": "2.0.0",
   "type": "module",
   "scripts": {
     "sync-version": "node ../tools/sync-version.mjs",

--- a/tests/test_updater_install.py
+++ b/tests/test_updater_install.py
@@ -9,14 +9,14 @@ from backend import updater
 
 
 def test_pick_windows_asset_accepts_plain_executable() -> None:
-    asset = {"name": "VlierPlanner-1.4.1.exe", "browser_download_url": "https://example.invalid"}
+    asset = {"name": "VlierPlanner-2.0.0.exe", "browser_download_url": "https://example.invalid"}
     result = updater._pick_windows_asset([asset])
     assert result is asset
 
 
 def test_pick_windows_asset_prefers_setup_named_assets() -> None:
-    plain = {"name": "VlierPlanner-1.4.1.exe", "browser_download_url": "https://example.invalid/plain"}
-    setup = {"name": "VlierPlanner-Setup-1.4.1.exe", "browser_download_url": "https://example.invalid/setup"}
+    plain = {"name": "VlierPlanner-2.0.0.exe", "browser_download_url": "https://example.invalid/plain"}
+    setup = {"name": "VlierPlanner-Setup-2.0.0.exe", "browser_download_url": "https://example.invalid/setup"}
     result = updater._pick_windows_asset([plain, setup])
     assert result is setup
 


### PR DESCRIPTION
## Samenvatting
- werk de applicatieversie bij naar 2.0.0 en synchroniseer de frontendconfiguratie
- actualiseer de updater-test zodat deze naar de nieuwe bestandsnamen verwijst
- documenteer het stappenplan en de releasenotes voor de eerste stabiele release in `docs/release-v2.0.0.md`

## Testen
- PYTHONPATH=. pytest tests/test_updater_install.py

------
https://chatgpt.com/codex/tasks/task_e_68d950c7e95083229e3b2e3f276eeaa2