### PR TITLE
Herstel ontbrekende data_store import

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -77,6 +77,11 @@ except ImportError:  # pragma: no cover
     import update_checker  # type: ignore
 
 try:
+    from .services.data_store import data_store
+except ImportError:  # pragma: no cover
+    from services.data_store import data_store  # type: ignore
+
+try:
     from .school_vacations import fetch_school_vacations
 except ImportError:  # pragma: no cover
     from school_vacations import fetch_school_vacations  # type: ignore


### PR DESCRIPTION
## Samenvatting
- voeg de ontbrekende import van `data_store` toe in de backend-app zodat de opslaglaag correct wordt geïnitialiseerd

## Testen
- pytest tests/test_study_guides_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d9584f31c483228cd0d3953d2b58de