### PR TITLE
Breid ChromeOS-release uit met dubbelklik-installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Vlier Planner helpt leerlingen en docenten om studiewijzers uit het voortgezet o
 8. [Frontend-build koppelen](#frontend-build-koppelen)
 9. [Alles-in-één backend](#alles-in-één-backend)
 10. [Windows distributie](#windows-distributie)
-11. [Licentie](#licentie)
+11. [ChromeOS distributie](#chromeos-distributie)
+12. [Licentie](#licentie)
 
 ## Functioneel overzicht
 ### Belangrijkste schermen
@@ -188,6 +189,21 @@ Volg deze stappen om een enkel `.exe`-bestand te maken voor Windows-gebruikers:
    Pas opties als `--add-data` of `--collect-all` aan wanneer extra pakketten of assets nodig zijn. Je kunt ook `pyinstaller VlierPlanner.spec` gebruiken; dezelfde version resource wordt dan automatisch toegevoegd.
 5. Het resultaat vind je in `dist/VlierPlanner.exe`. Kopieer dit bestand naar een Windows-machine en start het met een dubbelklik; de app opent automatisch op `http://127.0.0.1:8000`.
 6. (Optioneel) Gebruik Inno en "installer.iss" file voor het maken van een installer executable. Deze komt dan in "buils/installer/VlierPlanner-Setup-[version].exe" te staan.
+
+## ChromeOS distributie
+
+Chromebooks met Linux-ondersteuning kunnen dezelfde PyInstaller-build draaien.
+Gebruik `tools/build_chromeos_release.py` om zowel een `.deb`-installer als een
+handmatig uit te pakken bundel (`tar.gz`) te maken.
+
+```bash
+python tools/build_chromeos_release.py
+```
+
+Het script plaatst de output in `build/chromeos/`. Zie
+[`docs/chromeos-release.md`](docs/chromeos-release.md) voor een stap-voor-stap
+handleiding, inclusief installatie op het doelapparaat met een
+dubbelklik-installer.
 
 ## Licentie
 MIT

--- a/docs/chromeos-release.md
+++ b/docs/chromeos-release.md
@@ -1,0 +1,58 @@
+# ChromeOS-release maken
+
+Deze handleiding beschrijft hoe je een distributiepakket maakt voor Chromebooks
+met de Linux (Crostini) omgeving. Het hulpscript bouwt zowel een handmatig
+uit te pakken archief als een `.deb`-installer zodat gebruikers de app kunnen
+installeren door simpelweg op een pakket te dubbelklikken.
+
+## Voorbereiding
+
+1. Zorg dat Node.js, npm, PyInstaller en `dpkg-deb` in je pad beschikbaar zijn.
+2. Controleer of `VERSION.ini` de juiste versie bevat. Pas je de versie aan,
+   voer dan ook `npm run sync-version` uit in de map `frontend` zodat
+   `package.json` en `package-lock.json` overeenkomen.
+3. Werk je documentatie of configuratie bij? Commit die wijzigingen samen met de
+   release-aanpassingen voor context.
+
+## Pakket bouwen
+
+Voer vanuit de projectroot het hulpscript uit:
+
+```bash
+python tools/build_chromeos_release.py
+```
+
+Het script voert de volgende stappen uit:
+
+1. Frontend build (standaard met bestaande `node_modules`, zonder `npm install`).
+2. PyInstaller build op basis van `VlierPlanner.spec`.
+3. Bundelen van de output in `build/chromeos/VlierPlanner-ChromeOS-<versie>/`.
+4. Aanmaken van `VlierPlanner-ChromeOS-<versie>.tar.gz` **én** een
+   Debian-pakket `vlier-planner_<versie>_<architectuur>.deb`.
+
+Gebruik de optionele vlaggen als je bepaalde stappen wilt overslaan:
+
+- `--skip-frontend` – slaat het frontend buildproces over.
+- `--with-install` – voert vooraf `npm install` uit zodat afhankelijkheden zijn
+  bijgewerkt voordat de build start.
+- `--skip-pyinstaller` – gebruikt de huidige inhoud van `dist/VlierPlanner`.
+
+## Installatie op een Chromebook
+
+### Standaard: via `.deb`-pakket
+
+1. Kopieer het bestand `vlier-planner_<versie>_<architectuur>.deb` naar de Chromebook.
+2. Dubbelklik op het bestand in de bestandsbeheerder en volg de installatie-
+   dialoog van ChromeOS. De installer plaatst automatisch een starticoon in het
+   app-overzicht.
+3. Na installatie kun je Vlier Planner starten vanuit de launcher of via de
+   terminal met `vlier-planner`.
+
+### Alternatief: handmatige installatie
+
+1. Kopieer `VlierPlanner-ChromeOS-<versie>.tar.gz` naar de Chromebook en pak het
+   archief uit in een map naar keuze, bij voorkeur `~/Apps`.
+2. Maak het startscript uitvoerbaar met `chmod +x start-vlier-planner.sh`.
+3. (Optioneel) Kopieer `vlier-planner.desktop` naar `~/.local/share/applications/`
+   voor een snelkoppeling in de launcher.
+4. Start de applicatie vanuit dezelfde map met `./start-vlier-planner.sh`.

--- a/tools/build_chromeos_release.py
+++ b/tools/build_chromeos_release.py
@@ -1,0 +1,329 @@
+"""Hulpscript om een distributiepakket voor ChromeOS samen te stellen.
+
+Dit script combineert de PyInstaller-build met een startscript, levert een
+handmatig uit te pakken `tar.gz` op en bouwt daarnaast een `.deb`-pakket voor
+Chromebooks met de Linux-omgeving. Het script veronderstelt dat Node.js,
+PyInstaller en `dpkg-deb` beschikbaar zijn in de huidige omgeving.
+"""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import platform
+import shutil
+import subprocess
+import sys
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DIST_DIR = ROOT / "dist" / "VlierPlanner"
+BUILD_DIR = ROOT / "build" / "chromeos"
+FRONTEND_LOGO = ROOT / "frontend" / "public" / "logo.png"
+
+
+@dataclass
+class BundleInfo:
+    root: Path
+    binary_name: str
+    app_dir: Path
+
+
+def read_version() -> str:
+    config = configparser.ConfigParser()
+    version_file = ROOT / "VERSION.ini"
+
+    if not config.read(version_file):
+        raise SystemExit(f"VERSION.ini niet gevonden of leeg op {version_file}.")
+
+    # Zoek eerst naar een expliciet sectieveld 'version'.
+    for section in config.sections():
+        if config.has_option(section, "version"):
+            value = config.get(section, "version").strip()
+            if value:
+                return value
+
+    # Val terug op de default sectie indien aanwezig.
+    if config.has_option(config.default_section, "version"):
+        value = config.get(config.default_section, "version").strip()
+        if value:
+            return value
+
+    raise SystemExit("Kon geen versie uitlezen uit VERSION.ini")
+
+
+def resolve_tool(name: str) -> str:
+    resolved = shutil.which(name)
+    if not resolved:
+        raise SystemExit(f"Kon hulpprogramma '{name}' niet vinden in PATH.")
+    return resolved
+
+
+def run(cmd: list[str], cwd: Path | None = None) -> None:
+    subprocess.run(cmd, cwd=cwd, check=True)
+
+
+def build_frontend(run_install: bool) -> None:
+    script = ROOT / "tools" / "build_frontend.py"
+    args = [] if run_install else ["--skip-install"]
+    run([sys.executable, str(script), *args], cwd=ROOT)
+
+
+def build_pyinstaller() -> None:
+    pyinstaller = resolve_tool("pyinstaller")
+    run([pyinstaller, "--noconfirm", "VlierPlanner.spec"], cwd=ROOT)
+
+
+def prepare_bundle(version: str) -> BundleInfo:
+    bundle_root = BUILD_DIR / f"VlierPlanner-ChromeOS-{version}"
+    if bundle_root.exists():
+        shutil.rmtree(bundle_root)
+    bundle_root.mkdir(parents=True)
+
+    if not DIST_DIR.exists():
+        raise SystemExit(
+            "PyInstaller-output niet gevonden. Draai eerst pyinstaller VlierPlanner.spec."
+        )
+
+    app_target = bundle_root / "app"
+    shutil.copytree(DIST_DIR, app_target)
+
+    binary_name = None
+    for candidate in ("VlierPlanner", "VlierPlanner.exe"):
+        if (app_target / candidate).exists():
+            binary_name = candidate
+            break
+
+    if not binary_name:
+        raise SystemExit(
+            "Kon geen PyInstaller-binary vinden in dist/VlierPlanner; verwacht 'VlierPlanner' of 'VlierPlanner.exe'."
+        )
+
+    launcher = bundle_root / "start-vlier-planner.sh"
+    launcher.write_text(
+        f'''#!/bin/sh
+set -e
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+APP_DIR="$SCRIPT_DIR/app"
+exec "$APP_DIR/{binary_name}" "$@"
+''',
+        encoding="utf-8",
+    )
+    launcher.chmod(0o755)
+
+    desktop_entry = bundle_root / "vlier-planner.desktop"
+    desktop_entry.write_text(
+        """[Desktop Entry]
+Type=Application
+Name=Vlier Planner
+Comment=Start de Vlier Planner applicatie
+Exec=sh -c "exec \"$(dirname \"$1\")\"/start-vlier-planner.sh" _ "%k"
+Icon=vlier-planner
+Terminal=false
+Categories=Education;
+""",
+        encoding="utf-8",
+    )
+
+    readme = bundle_root / "README-chromeos.md"
+    readme.write_text(
+        """# Vlier Planner – ChromeOS pakket
+
+Dit pakket is bedoeld voor Chromebooks met de Linux (Crostini) omgeving.
+
+## Installatie (handmatige methode)
+
+1. Pak het archief uit in een map naar keuze, bij voorkeur in `~/Apps` of `~/Programma's`.
+2. Zorg dat het script uitvoerbaar is: `chmod +x start-vlier-planner.sh`.
+3. (Optioneel) Kopieer `vlier-planner.desktop` naar `~/.local/share/applications/`
+   voor een snelkoppeling in de launcher.
+4. Start de applicatie met `./start-vlier-planner.sh`. De backend en frontend worden samen gestart in één PyInstaller-build.
+""",
+        encoding="utf-8",
+    )
+
+    if FRONTEND_LOGO.exists():
+        shutil.copy2(FRONTEND_LOGO, bundle_root / "vlier-planner.png")
+
+    return BundleInfo(root=bundle_root, binary_name=binary_name, app_dir=app_target)
+
+
+def create_archive(bundle_root: Path) -> Path:
+    archive_path = BUILD_DIR / f"{bundle_root.name}.tar.gz"
+    if archive_path.exists():
+        archive_path.unlink()
+
+    with tarfile.open(archive_path, "w:gz") as tar:
+        tar.add(bundle_root, arcname=bundle_root.name)
+
+    return archive_path
+
+
+def ensure_logo(target_path: Path) -> None:
+    if not FRONTEND_LOGO.exists():
+        return
+
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(FRONTEND_LOGO, target_path)
+
+
+def detect_deb_architecture(binary_path: Path) -> str:
+    if not binary_path.exists():
+        raise SystemExit(
+            f"PyInstaller-binary niet gevonden op {binary_path}; bouw eerst de applicatie."
+        )
+
+    machine = platform.machine().lower()
+    if machine in {"x86_64", "amd64"}:
+        return "amd64"
+    if machine in {"aarch64", "arm64"}:
+        return "arm64"
+    if machine in {"armv7l", "armhf"}:
+        return "armhf"
+
+    # Val terug op amd64 zodat dpkg-deb een consistente naam heeft; documenteer dit in de output.
+    print(
+        "Waarschuwing: onbekende architectuur '{machine}', val terug op 'amd64'.".format(
+            machine=machine
+        )
+    )
+    return "amd64"
+
+
+def create_deb_package(bundle: BundleInfo, version: str) -> Path:
+    architecture = detect_deb_architecture(bundle.app_dir / bundle.binary_name)
+    package_root = BUILD_DIR / f"vlierplanner_{version}_{architecture}"
+    if package_root.exists():
+        shutil.rmtree(package_root)
+
+    control_dir = package_root / "DEBIAN"
+    control_dir.mkdir(parents=True)
+
+    # Data directories
+    opt_dir = package_root / "opt" / "vlier-planner"
+    shutil.copytree(bundle.app_dir, opt_dir)
+
+    launcher_target = package_root / "usr" / "bin" / "vlier-planner"
+    launcher_target.parent.mkdir(parents=True, exist_ok=True)
+    launcher_target.write_text(
+        f"""#!/bin/sh
+set -e
+APP_DIR="/opt/vlier-planner"
+exec "$APP_DIR/{bundle.binary_name}" "$@"
+""",
+        encoding="utf-8",
+    )
+    launcher_target.chmod(0o755)
+
+    desktop_target = package_root / "usr" / "share" / "applications" / "vlier-planner.desktop"
+    desktop_target.parent.mkdir(parents=True, exist_ok=True)
+    desktop_target.write_text(
+        """[Desktop Entry]
+Type=Application
+Name=Vlier Planner
+Comment=Plan lessen en studiewijzers voor het Vlier
+Exec=vlier-planner
+Icon=vlier-planner
+Terminal=false
+Categories=Education;
+""",
+        encoding="utf-8",
+    )
+
+    icon_target = package_root / "usr" / "share" / "icons" / "hicolor" / "256x256" / "apps" / "vlier-planner.png"
+    ensure_logo(icon_target)
+
+    readme_target = package_root / "usr" / "share" / "doc" / "vlier-planner"
+    readme_target.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(bundle.root / "README-chromeos.md", readme_target / "README.md")
+
+    control_fields = f"""Package: vlier-planner
+Version: {version}
+Section: utils
+Priority: optional
+Architecture: {architecture}
+Maintainer: Vlier Planner Team
+Description: Vlier Planner applicatie voor Chromebooks
+"""
+    (control_dir / "control").write_text(control_fields, encoding="utf-8")
+
+    postinst = control_dir / "postinst"
+    postinst.write_text(
+        """#!/bin/sh
+set -e
+chmod +x /opt/vlier-planner/* || true
+update-desktop-database >/dev/null 2>&1 || true
+exit 0
+""",
+        encoding="utf-8",
+    )
+    postinst.chmod(0o755)
+
+    prerm = control_dir / "prerm"
+    prerm.write_text(
+        """#!/bin/sh
+set -e
+update-desktop-database >/dev/null 2>&1 || true
+exit 0
+""",
+        encoding="utf-8",
+    )
+    prerm.chmod(0o755)
+
+    deb_path = BUILD_DIR / f"vlier-planner_{version}_{architecture}.deb"
+    if deb_path.exists():
+        deb_path.unlink()
+
+    dpkg_deb = resolve_tool("dpkg-deb")
+    run([dpkg_deb, "--build", str(package_root), str(deb_path)])
+
+    return deb_path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Bouw een ChromeOS-release door frontend en PyInstaller-output te bundelen."
+    )
+    parser.add_argument(
+        "--skip-frontend",
+        action="store_true",
+        help="Sla het opnieuw bouwen van de frontend over (verwacht bestaande dist).",
+    )
+    parser.add_argument(
+        "--with-install",
+        action="store_true",
+        help="Voer ook 'npm install' uit voordat de frontend wordt gebouwd.",
+    )
+    parser.add_argument(
+        "--skip-pyinstaller",
+        action="store_true",
+        help="Herbruik de huidige PyInstaller-output in dist/VlierPlanner.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    version = read_version()
+
+    BUILD_DIR.mkdir(parents=True, exist_ok=True)
+
+    if not args.skip_frontend:
+        build_frontend(run_install=args.with_install)
+
+    if not args.skip_pyinstaller:
+        build_pyinstaller()
+
+    bundle = prepare_bundle(version)
+    archive = create_archive(bundle.root)
+    deb_path = create_deb_package(bundle, version)
+
+    print(f"ChromeOS-build klaar in {bundle.root}")
+    print(f"Archief: {archive}")
+    print(f"Debian-pakket: {deb_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Samenvatting
- voeg Debian-pakketbouw toe aan het ChromeOS-buildscript zodat leerlingen via een dubbelklik kunnen installeren
- verrijk de ChromeOS-handleiding met instructies voor de installer en een voorbeeld .desktop-bestand voor de handmatige route
- werk de README bij zodat de nieuwe output en installatie-aanpak zichtbaar zijn

## Testen
- python -m compileall tools/build_chromeos_release.py

------
https://chatgpt.com/codex/tasks/task_e_68e4120d0e988322acbeb94fac59c5ce