### PR TITLE
Voeg instelling toe voor verborgen huiswerk

### DIFF
--- a/frontend/src/pages/Matrix.tsx
+++ b/frontend/src/pages/Matrix.tsx
@@ -93,6 +93,7 @@ function MatrixCell({
   const updateCustomHomework = useAppStore((s) => s.updateCustomHomework);
   const enableHomeworkEditing = useAppStore((s) => s.enableHomeworkEditing);
   const enableCustomHomework = useAppStore((s) => s.enableCustomHomework);
+  const showDeletedHomework = useAppStore((s) => s.showDeletedHomework);
   const storedItems =
     Array.isArray(data?.huiswerkItems) && data?.huiswerkItems.length
       ? data.huiswerkItems
@@ -489,7 +490,7 @@ function MatrixCell({
               {deadlineLabel}
             </div>
           )}
-          {hiddenAutoItems.length > 0 && (
+          {hiddenAutoItems.length > 0 && showDeletedHomework && (
             <div className="rounded-md border border-dashed theme-border px-2 py-1 text-xs theme-muted">
               <div className="font-semibold uppercase tracking-wide text-[0.65rem]">Verborgen huiswerk</div>
               <ul className="mt-1 space-y-1">

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -8,6 +8,8 @@ export default function Settings() {
     setMijnVakken,
     huiswerkWeergave,
     setHuiswerkWeergave,
+    showDeletedHomework,
+    setShowDeletedHomework,
     themePresets,
     activeThemeId,
     setActiveTheme,
@@ -345,6 +347,20 @@ export default function Settings() {
               <div className="text-sm font-medium theme-text">Bewerken en verwijderen toestaan</div>
               <div className="text-xs leading-snug theme-muted">
                 Verberg de potlood- en prullenbakknoppen bij huiswerk wanneer dit is uitgeschakeld.
+              </div>
+            </div>
+          </label>
+          <label className="flex items-start gap-3 rounded-md border theme-border theme-soft p-3">
+            <input
+              type="checkbox"
+              checked={showDeletedHomework}
+              onChange={(event) => setShowDeletedHomework(event.target.checked)}
+              className="mt-1"
+            />
+            <div className="flex-1">
+              <div className="text-sm font-medium theme-text">Verwijderd huiswerk tonen</div>
+              <div className="text-xs leading-snug theme-muted">
+                Laat verborgen opdrachten onderaan kaarten en in de matrix zien zodat je ze kunt herstellen.
               </div>
             </div>
           </label>

--- a/frontend/src/pages/WeekOverview.tsx
+++ b/frontend/src/pages/WeekOverview.tsx
@@ -86,6 +86,7 @@ function Card({
   const updateCustomHomework = useAppStore((s) => s.updateCustomHomework);
   const enableHomeworkEditing = useAppStore((s) => s.enableHomeworkEditing);
   const enableCustomHomework = useAppStore((s) => s.enableCustomHomework);
+  const showDeletedHomework = useAppStore((s) => s.showDeletedHomework);
   const multiWeekSpans = Array.isArray(data?.multiWeekSpans) ? data!.multiWeekSpans : [];
   const startSpanMessages = multiWeekSpans.filter((span) => span.role === "start");
   const continueSpanMessages = multiWeekSpans.filter((span) => span.role === "continue");
@@ -535,7 +536,7 @@ function Card({
           </div>
         )}
   
-        {hiddenAutoItems.length > 0 && (
+        {hiddenAutoItems.length > 0 && showDeletedHomework && (
           <div className="rounded-md border border-dashed theme-border px-2 py-1 text-xs theme-muted">
             <div className="font-semibold uppercase tracking-wide text-[0.65rem]">Verborgen huiswerk</div>
             <ul className="mt-1 space-y-1">


### PR DESCRIPTION
## Samenvatting
- voeg een nieuwe toggle toe waarmee gebruikers verborgen/ verwijderde huiswerktaken kunnen tonen of verbergen in het week- en matricoverzicht
- sla de keuze op in de store en migreer bestaande state zodat de instelling optioneel blijft
- toon verborgen taken alleen nog wanneer de instelling aan staat

## Tests
- `cd frontend && npm test -- src/pages/__tests__/WeekOverview.test.tsx`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d8cd9d44c8322b9dec9ce15c4f7d3)