### PR TITLE
Voorkom onnodige redirect naar uitleg

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -109,7 +109,7 @@ function AppContent({ hasHydratedStore }: AppContentProps) {
       return;
     }
 
-    if (prev !== hasDocs) {
+    if (!prev && hasDocs) {
       setInitialRouteHandled(false);
     }
   }, [hasDocs, docsInitialized, hasHydratedStore]);


### PR DESCRIPTION
## Samenvatting
- pas de routeringslogica aan zodat we alleen nog naar /uitleg sturen na de eerste succesvolle hydratatie met documenten
- zorg er daardoor voor dat het legen van uploads of een reset in Instellingen de gebruiker op de huidige pagina laat

## Tests
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ddda1bb9483228dbd86e6a89f95d7)